### PR TITLE
Support content URIs properly for uploads on Android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,9 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.RNFetchBlob">
-
-    <application
-        android:label="@string/app_name">
-
-    </application>
-
 </manifest>

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobBody.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobBody.java
@@ -351,8 +351,6 @@ public class RNFetchBlobBody extends RequestBody{
                 } else if (data.startsWith(RNFetchBlobConst.CONTENT_PREFIX)) {
                     try {
                         String contentUri = data.substring(RNFetchBlobConst.CONTENT_PREFIX.length());
-                        RNFetchBlobUtils.emitWarningEvent("contentUri=" + contentUri);
-
                         long length = ctx.getContentResolver().openInputStream(Uri.parse(contentUri)).available();
                         total += length;
                     } catch (IOException e) {

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobConst.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobConst.java
@@ -14,5 +14,6 @@ public class RNFetchBlobConst {
     public static final String RNFB_RESPONSE_UTF8  = "utf8";
     public static final String RNFB_RESPONSE_PATH  = "path";
     public static final Integer GET_CONTENT_INTENT = 99900;
+    public static final String CONTENT_PREFIX = "RNFetchBlob-content://";
 
 }

--- a/index.js
+++ b/index.js
@@ -79,7 +79,11 @@ if(!RNFetchBlob || !RNFetchBlob.fetchBlobForm || !RNFetchBlob.fetchBlob) {
 }
 
 function wrap(path:string):string {
-  return 'RNFetchBlob-file://' + path
+  if (path.startsWith('content://')) {
+    return 'RNFetchBlob-content://' + path
+  } else {
+    return 'RNFetchBlob-file://' + path
+  }
 }
 
 /**


### PR DESCRIPTION
Content URIs can point to "virtual files" on Android. Rather than trying to determine an actual file path for these URIs, which may or may not exist, stream the input without a file path.

This isn't a complete PR as it focuses on uploads only. Someone will probably need to add some logic in for local file access.