### PR TITLE
Handle failure when download to FileStorage

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -511,11 +511,12 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                     // It uses customized response body which is able to report download progress
                     // and write response data to destination path.
                     resp.body().bytes();
+
+                    this.destPath = this.destPath.replace("?append=true", "");
+                    callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_PATH, this.destPath);
                 } catch (Exception ignored) {
-//                    ignored.printStackTrace();
+                    callback.invoke("RNFetchBlob failed.", null);
                 }
-                this.destPath = this.destPath.replace("?append=true", "");
-                callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_PATH, this.destPath);
                 break;
             default:
                 try {


### PR DESCRIPTION
This PR fixes an issue (and inconsistency between iOS and Android) when promise successfully resolved in case of network failure. I'm not sure why this exception was ignored in first place. Other cases always fail from exception.