### PR TITLE
Synchronized

### DIFF
--- a/ios/RNFetchBlob.xcodeproj/project.pbxproj
+++ b/ios/RNFetchBlob.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8C4801A6200CF71700FED7ED /* RNFetchBlobRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C4801A5200CF71700FED7ED /* RNFetchBlobRequest.m */; };
 		A158F4271D052E49006FFD38 /* RNFetchBlobFS.m in Sources */ = {isa = PBXBuildFile; fileRef = A158F4261D052E49006FFD38 /* RNFetchBlobFS.m */; };
 		A158F42D1D0535BB006FFD38 /* RNFetchBlobConst.m in Sources */ = {isa = PBXBuildFile; fileRef = A158F42C1D0535BB006FFD38 /* RNFetchBlobConst.m */; };
 		A158F4301D0539DB006FFD38 /* RNFetchBlobNetwork.m in Sources */ = {isa = PBXBuildFile; fileRef = A158F42F1D0539DB006FFD38 /* RNFetchBlobNetwork.m */; };
@@ -29,6 +30,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		8C4801A4200CF71700FED7ED /* RNFetchBlobRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNFetchBlobRequest.h; sourceTree = "<group>"; };
+		8C4801A5200CF71700FED7ED /* RNFetchBlobRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNFetchBlobRequest.m; sourceTree = "<group>"; };
 		A158F4261D052E49006FFD38 /* RNFetchBlobFS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNFetchBlobFS.m; sourceTree = "<group>"; };
 		A158F4281D052E57006FFD38 /* RNFetchBlobFS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNFetchBlobFS.h; sourceTree = "<group>"; };
 		A158F4291D0534A9006FFD38 /* RNFetchBlobConst.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNFetchBlobConst.h; sourceTree = "<group>"; };
@@ -71,8 +74,10 @@
 				A1F950181D7E9134002A95A6 /* IOS7Polyfill.h */,
 				A1AAE2981D300E4D0051D11C /* RNFetchBlobReqBuilder.m */,
 				A1AAE2971D300E3E0051D11C /* RNFetchBlobReqBuilder.h */,
-				A158F42F1D0539DB006FFD38 /* RNFetchBlobNetwork.m */,
 				A158F42E1D0539CE006FFD38 /* RNFetchBlobNetwork.h */,
+				A158F42F1D0539DB006FFD38 /* RNFetchBlobNetwork.m */,
+				8C4801A4200CF71700FED7ED /* RNFetchBlobRequest.h */,
+				8C4801A5200CF71700FED7ED /* RNFetchBlobRequest.m */,
 				A158F42C1D0535BB006FFD38 /* RNFetchBlobConst.m */,
 				A158F4291D0534A9006FFD38 /* RNFetchBlobConst.h */,
 				A158F4281D052E57006FFD38 /* RNFetchBlobFS.h */,
@@ -149,6 +154,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A166D1AA1CE0647A00273590 /* RNFetchBlob.h in Sources */,
+				8C4801A6200CF71700FED7ED /* RNFetchBlobRequest.m in Sources */,
 				A158F42D1D0535BB006FFD38 /* RNFetchBlobConst.m in Sources */,
 				A158F4271D052E49006FFD38 /* RNFetchBlobFS.m in Sources */,
 				A158F4301D0539DB006FFD38 /* RNFetchBlobNetwork.m in Sources */,

--- a/ios/RNFetchBlob/RNFetchBlob.h
+++ b/ios/RNFetchBlob/RNFetchBlob.h
@@ -39,7 +39,6 @@
 @property (retain) UIDocumentInteractionController * documentController;
 
 + (RCTBridge *)getRCTBridge;
-+ (void) checkExpiredSessions;
 
 @end
 

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -96,8 +96,12 @@ RCT_EXPORT_METHOD(fetchBlobForm:(NSDictionary *)options
         // send HTTP request
         else
         {
-            RNFetchBlobNetwork * utils = [[RNFetchBlobNetwork alloc] init];
-            [utils sendRequest:options contentLength:bodyLength bridge:self.bridge taskId:taskId withRequest:req callback:callback];
+            [RNFetchBlobNetwork sendRequest:options
+                              contentLength:bodyLength
+                                     bridge:self.bridge
+                                     taskId:taskId
+                                withRequest:req
+                                   callback:callback];
         }
     }];
 
@@ -128,8 +132,12 @@ RCT_EXPORT_METHOD(fetchBlob:(NSDictionary *)options
         // send HTTP request
         else
         {
-            RNFetchBlobNetwork * utils = [[RNFetchBlobNetwork alloc] init];
-            [utils sendRequest:options contentLength:bodyLength bridge:self.bridge taskId:taskId withRequest:req callback:callback];
+            [RNFetchBlobNetwork sendRequest:options
+                              contentLength:bodyLength
+                                     bridge:self.bridge
+                                     taskId:taskId
+                                withRequest:req
+                                   callback:callback];
         }
     }];
 }

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -38,7 +38,7 @@ dispatch_queue_t fsQueue;
 
 + (RCTBridge *)getRCTBridge
 {
-    RCTRootView * rootView = [[UIApplication sharedApplication] keyWindow].rootViewController.view;
+    RCTRootView * rootView = (RCTRootView*) [[UIApplication sharedApplication] keyWindow].rootViewController.view;
     return rootView.bridge;
 }
 
@@ -128,7 +128,7 @@ RCT_EXPORT_METHOD(fetchBlob:(NSDictionary *)options
         // send HTTP request
         else
         {
-            __block RNFetchBlobNetwork * utils = [[RNFetchBlobNetwork alloc] init];
+            RNFetchBlobNetwork * utils = [[RNFetchBlobNetwork alloc] init];
             [utils sendRequest:options contentLength:bodyLength bridge:self.bridge taskId:taskId withRequest:req callback:callback];
         }
     }];

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -96,12 +96,12 @@ RCT_EXPORT_METHOD(fetchBlobForm:(NSDictionary *)options
         // send HTTP request
         else
         {
-            [RNFetchBlobNetwork sendRequest:options
-                              contentLength:bodyLength
-                                     bridge:self.bridge
-                                     taskId:taskId
-                                withRequest:req
-                                   callback:callback];
+            [[RNFetchBlobNetwork sharedInstance] sendRequest:options
+                                               contentLength:bodyLength
+                                                      bridge:self.bridge
+                                                      taskId:taskId
+                                                 withRequest:req
+                                                    callback:callback];
         }
     }];
 
@@ -132,12 +132,12 @@ RCT_EXPORT_METHOD(fetchBlob:(NSDictionary *)options
         // send HTTP request
         else
         {
-            [RNFetchBlobNetwork sendRequest:options
-                              contentLength:bodyLength
-                                     bridge:self.bridge
-                                     taskId:taskId
-                                withRequest:req
-                                   callback:callback];
+            [[RNFetchBlobNetwork sharedInstance] sendRequest:options
+                                               contentLength:bodyLength
+                                                      bridge:self.bridge
+                                                      taskId:taskId
+                                                 withRequest:req
+                                                    callback:callback];
         }
     }];
 }
@@ -496,7 +496,7 @@ RCT_EXPORT_METHOD(getEnvironmentDirs:(RCTResponseSenderBlock) callback)
 
 #pragma mark - net.cancelRequest
 RCT_EXPORT_METHOD(cancelRequest:(NSString *)taskId callback:(RCTResponseSenderBlock)callback) {
-    [RNFetchBlobNetwork cancelRequest:taskId];
+    [[RNFetchBlobNetwork sharedInstance] cancelRequest:taskId];
     callback(@[[NSNull null], taskId]);
 
 }
@@ -506,14 +506,14 @@ RCT_EXPORT_METHOD(enableProgressReport:(NSString *)taskId interval:(nonnull NSNu
 {
 
     RNFetchBlobProgress * cfg = [[RNFetchBlobProgress alloc] initWithType:Download interval:interval count:count];
-    [RNFetchBlobNetwork enableProgressReport:taskId config:cfg];
+    [[RNFetchBlobNetwork sharedInstance] enableProgressReport:taskId config:cfg];
 }
 
 #pragma mark - net.enableUploadProgressReport
 RCT_EXPORT_METHOD(enableUploadProgressReport:(NSString *)taskId interval:(nonnull NSNumber*)interval count:(nonnull NSNumber*)count)
 {
     RNFetchBlobProgress * cfg = [[RNFetchBlobProgress alloc] initWithType:Upload interval:interval count:count];
-    [RNFetchBlobNetwork enableUploadProgress:taskId config:cfg];
+    [[RNFetchBlobNetwork sharedInstance] enableUploadProgress:taskId config:cfg];
 }
 
 #pragma mark - fs.slice

--- a/ios/RNFetchBlobConst.m
+++ b/ios/RNFetchBlobConst.m
@@ -7,38 +7,38 @@
 //
 #import "RNFetchBlobConst.h"
 
-extern NSString *const FILE_PREFIX = @"RNFetchBlob-file://";
-extern NSString *const ASSET_PREFIX = @"bundle-assets://";
-extern NSString *const AL_PREFIX = @"assets-library://";
+NSString *const FILE_PREFIX = @"RNFetchBlob-file://";
+NSString *const ASSET_PREFIX = @"bundle-assets://";
+NSString *const AL_PREFIX = @"assets-library://";
 
 // fetch configs
-extern NSString *const CONFIG_USE_TEMP = @"fileCache";
-extern NSString *const CONFIG_FILE_PATH = @"path";
-extern NSString *const CONFIG_FILE_EXT = @"appendExt";
-extern NSString *const CONFIG_TRUSTY = @"trusty";
-extern NSString *const CONFIG_INDICATOR = @"indicator";
-extern NSString *const CONFIG_KEY = @"key";
-extern NSString *const CONFIG_EXTRA_BLOB_CTYPE = @"binaryContentTypes";
+NSString *const CONFIG_USE_TEMP = @"fileCache";
+NSString *const CONFIG_FILE_PATH = @"path";
+NSString *const CONFIG_FILE_EXT = @"appendExt";
+NSString *const CONFIG_TRUSTY = @"trusty";
+NSString *const CONFIG_INDICATOR = @"indicator";
+NSString *const CONFIG_KEY = @"key";
+NSString *const CONFIG_EXTRA_BLOB_CTYPE = @"binaryContentTypes";
 
-extern NSString *const EVENT_STATE_CHANGE = @"RNFetchBlobState";
-extern NSString *const EVENT_SERVER_PUSH = @"RNFetchBlobServerPush";
-extern NSString *const EVENT_PROGRESS = @"RNFetchBlobProgress";
-extern NSString *const EVENT_PROGRESS_UPLOAD = @"RNFetchBlobProgress-upload";
-extern NSString *const EVENT_EXPIRE = @"RNFetchBlobExpire";
+NSString *const EVENT_STATE_CHANGE = @"RNFetchBlobState";
+NSString *const EVENT_SERVER_PUSH = @"RNFetchBlobServerPush";
+NSString *const EVENT_PROGRESS = @"RNFetchBlobProgress";
+NSString *const EVENT_PROGRESS_UPLOAD = @"RNFetchBlobProgress-upload";
+NSString *const EVENT_EXPIRE = @"RNFetchBlobExpire";
 
-extern NSString *const MSG_EVENT = @"RNFetchBlobMessage";
-extern NSString *const MSG_EVENT_LOG = @"log";
-extern NSString *const MSG_EVENT_WARN = @"warn";
-extern NSString *const MSG_EVENT_ERROR = @"error";
-extern NSString *const FS_EVENT_DATA = @"data";
-extern NSString *const FS_EVENT_END = @"end";
-extern NSString *const FS_EVENT_WARN = @"warn";
-extern NSString *const FS_EVENT_ERROR = @"error";
+NSString *const MSG_EVENT = @"RNFetchBlobMessage";
+NSString *const MSG_EVENT_LOG = @"log";
+NSString *const MSG_EVENT_WARN = @"warn";
+NSString *const MSG_EVENT_ERROR = @"error";
+NSString *const FS_EVENT_DATA = @"data";
+NSString *const FS_EVENT_END = @"end";
+NSString *const FS_EVENT_WARN = @"warn";
+NSString *const FS_EVENT_ERROR = @"error";
 
-extern NSString *const KEY_REPORT_PROGRESS = @"reportProgress";
-extern NSString *const KEY_REPORT_UPLOAD_PROGRESS = @"reportUploadProgress";
+NSString *const KEY_REPORT_PROGRESS = @"reportProgress";
+NSString *const KEY_REPORT_UPLOAD_PROGRESS = @"reportUploadProgress";
 
 // response type
-extern NSString *const RESP_TYPE_BASE64 = @"base64";
-extern NSString *const RESP_TYPE_UTF8 = @"utf8";
-extern NSString *const RESP_TYPE_PATH = @"path";
+NSString *const RESP_TYPE_BASE64 = @"base64";
+NSString *const RESP_TYPE_UTF8 = @"utf8";
+NSString *const RESP_TYPE_PATH = @"path";

--- a/ios/RNFetchBlobFS.h
+++ b/ios/RNFetchBlobFS.h
@@ -34,8 +34,8 @@
     NSString * streamId;
 }
 
-@property (nonatomic) NSOutputStream * outStream;
-@property (nonatomic) NSInputStream * inStream;
+@property (nonatomic) NSOutputStream * _Nullable outStream;
+@property (nonatomic) NSInputStream * _Nullable inStream;
 @property (strong, nonatomic) RCTResponseSenderBlock callback;
 @property (nonatomic) RCTBridge * bridge;
 @property (nonatomic) NSString * encoding;

--- a/ios/RNFetchBlobNetwork.h
+++ b/ios/RNFetchBlobNetwork.h
@@ -6,6 +6,9 @@
 //  Copyright © 2016 wkh237. All rights reserved.
 //
 
+#ifndef RNFetchBlobNetwork_h
+#define RNFetchBlobNetwork_h
+
 #import <Foundation/Foundation.h>
 #import "RNFetchBlobProgress.h"
 #import "RNFetchBlobFS.h"
@@ -16,9 +19,6 @@
 #else
 #import "RCTBridgeModule.h"
 #endif
-
-#ifndef RNFetchBlobNetwork_h
-#define RNFetchBlobNetwork_h
 
 
 @interface RNFetchBlobNetwork : NSObject  <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>

--- a/ios/RNFetchBlobNetwork.h
+++ b/ios/RNFetchBlobNetwork.h
@@ -20,39 +20,31 @@
 #define RNFetchBlobNetwork_h
 
 
-
 typedef void(^CompletionHander)(NSURL * _Nullable location, NSURLResponse * _Nullable response, NSError * _Nullable error);
 typedef void(^DataTaskCompletionHander) (NSData * _Nullable resp, NSURLResponse * _Nullable response, NSError * _Nullable error);
 
 @interface RNFetchBlobNetwork : NSObject  <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
 
 @property (nullable, nonatomic) NSString * taskId;
-@property (nonatomic) int expectedBytes;
-@property (nonatomic) int receivedBytes;
+@property (nonatomic) long long expectedBytes;
+@property (nonatomic) long long receivedBytes;
 @property (nonatomic) BOOL isServerPush;
 @property (nullable, nonatomic) NSMutableData * respData;
-@property (strong, nonatomic) RCTResponseSenderBlock callback;
+@property (nullable, strong, nonatomic) RCTResponseSenderBlock callback;
 @property (nullable, nonatomic) RCTBridge * bridge;
 @property (nullable, nonatomic) NSDictionary * options;
 @property (nullable, nonatomic) RNFetchBlobFS * fileStream;
-@property (strong, nonatomic) CompletionHander fileTaskCompletionHandler;
-@property (strong, nonatomic) DataTaskCompletionHander dataTaskCompletionHandler;
 @property (nullable, nonatomic) NSError * error;
 
 
 + (NSMutableDictionary  * _Nullable ) normalizeHeaders:(NSDictionary * _Nullable)headers;
-+ (void) cancelRequest:(NSString *)taskId;
-+ (void) enableProgressReport:(NSString *) taskId;
-+ (void) enableUploadProgress:(NSString *) taskId;
++ (void) cancelRequest:(NSString * _Nonnull)taskId;
 + (void) emitExpiredTasks;
++ (void) enableProgressReport:(NSString * _Nonnull) taskId config:(RNFetchBlobProgress * _Nullable)config;
++ (void) enableUploadProgress:(NSString * _Nonnull) taskId config:(RNFetchBlobProgress * _Nullable)config;
 
 - (nullable id) init;
-- (void) sendRequest;
 - (void) sendRequest:(NSDictionary  * _Nullable )options contentLength:(long)contentLength bridge:(RCTBridge * _Nullable)bridgeRef taskId:(NSString * _Nullable)taskId withRequest:(NSURLRequest * _Nullable)req callback:(_Nullable RCTResponseSenderBlock) callback;
-+ (void) enableProgressReport:(NSString *) taskId config:(RNFetchBlobProgress *)config;
-+ (void) enableUploadProgress:(NSString *) taskId config:(RNFetchBlobProgress *)config;
-
-
 
 @end
 

--- a/ios/RNFetchBlobNetwork.h
+++ b/ios/RNFetchBlobNetwork.h
@@ -20,9 +20,6 @@
 #define RNFetchBlobNetwork_h
 
 
-typedef void(^CompletionHander)(NSURL * _Nullable location, NSURLResponse * _Nullable response, NSError * _Nullable error);
-typedef void(^DataTaskCompletionHander) (NSData * _Nullable resp, NSURLResponse * _Nullable response, NSError * _Nullable error);
-
 @interface RNFetchBlobNetwork : NSObject  <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
 
 @property (nullable, nonatomic) NSString * taskId;

--- a/ios/RNFetchBlobNetwork.h
+++ b/ios/RNFetchBlobNetwork.h
@@ -22,18 +22,8 @@
 
 @interface RNFetchBlobNetwork : NSObject  <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
 
-@property (nullable, nonatomic) NSString * taskId;
-@property (nonatomic) long long expectedBytes;
-@property (nonatomic) long long receivedBytes;
-@property (nonatomic) BOOL isServerPush;
-@property (nullable, nonatomic) NSMutableData * respData;
-@property (nullable, strong, nonatomic) RCTResponseSenderBlock callback;
-@property (nullable, nonatomic) RCTBridge * bridge;
-@property (nullable, nonatomic) NSDictionary * options;
-@property (nullable, nonatomic) RNFetchBlobFS * fileStream;
-@property (nullable, nonatomic) NSError * error;
 
-
++ (_Nullable instancetype)sharedInstance;
 + (NSMutableDictionary  * _Nullable ) normalizeHeaders:(NSDictionary * _Nullable)headers;
 + (void) cancelRequest:(NSString * _Nonnull)taskId;
 + (void) emitExpiredTasks;
@@ -41,7 +31,7 @@
 + (void) enableUploadProgress:(NSString * _Nonnull) taskId config:(RNFetchBlobProgress * _Nullable)config;
 
 - (nullable id) init;
-- (void) sendRequest:(NSDictionary  * _Nullable )options contentLength:(long)contentLength bridge:(RCTBridge * _Nullable)bridgeRef taskId:(NSString * _Nullable)taskId withRequest:(NSURLRequest * _Nullable)req callback:(_Nullable RCTResponseSenderBlock) callback;
++ (void) sendRequest:(NSDictionary  * _Nullable )options contentLength:(long)contentLength bridge:(RCTBridge * _Nullable)bridgeRef taskId:(NSString * _Nullable)taskId withRequest:(NSURLRequest * _Nullable)req callback:(_Nullable RCTResponseSenderBlock) callback;
 
 @end
 

--- a/ios/RNFetchBlobNetwork.h
+++ b/ios/RNFetchBlobNetwork.h
@@ -28,13 +28,19 @@
 
 + (RNFetchBlobNetwork* _Nullable)sharedInstance;
 + (NSMutableDictionary  * _Nullable ) normalizeHeaders:(NSDictionary * _Nullable)headers;
-+ (void) cancelRequest:(NSString * _Nonnull)taskId;
 + (void) emitExpiredTasks;
-+ (void) enableProgressReport:(NSString * _Nonnull) taskId config:(RNFetchBlobProgress * _Nullable)config;
-+ (void) enableUploadProgress:(NSString * _Nonnull) taskId config:(RNFetchBlobProgress * _Nullable)config;
 
 - (nullable id) init;
-+ (void) sendRequest:(NSDictionary  * _Nullable )options contentLength:(long)contentLength bridge:(RCTBridge * _Nullable)bridgeRef taskId:(NSString * _Nullable)taskId withRequest:(NSURLRequest * _Nullable)req callback:(_Nullable RCTResponseSenderBlock) callback;
+- (void) sendRequest:(NSDictionary  * _Nullable )options
+       contentLength:(long)contentLength
+              bridge:(RCTBridge * _Nullable)bridgeRef
+              taskId:(NSString * _Nullable)taskId
+         withRequest:(NSURLRequest * _Nullable)req
+            callback:(_Nullable RCTResponseSenderBlock) callback;
+- (void) cancelRequest:(NSString * _Nonnull)taskId;
+- (void) enableProgressReport:(NSString * _Nonnull) taskId config:(RNFetchBlobProgress * _Nullable)config;
+- (void) enableUploadProgress:(NSString * _Nonnull) taskId config:(RNFetchBlobProgress * _Nullable)config;
+
 
 @end
 

--- a/ios/RNFetchBlobNetwork.h
+++ b/ios/RNFetchBlobNetwork.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "RNFetchBlobProgress.h"
 #import "RNFetchBlobFS.h"
+#import "RNFetchBlobRequest.h"
 
 #if __has_include(<React/RCTAssert.h>)
 #import <React/RCTBridgeModule.h>
@@ -22,8 +23,10 @@
 
 @interface RNFetchBlobNetwork : NSObject  <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
 
+@property(nonnull, nonatomic) NSOperationQueue *taskQueue;
+@property(nonnull, nonatomic) NSMapTable<NSString*, RNFetchBlobRequest*> * requestsTable;
 
-+ (_Nullable instancetype)sharedInstance;
++ (RNFetchBlobNetwork* _Nullable)sharedInstance;
 + (NSMutableDictionary  * _Nullable ) normalizeHeaders:(NSDictionary * _Nullable)headers;
 + (void) cancelRequest:(NSString * _Nonnull)taskId;
 + (void) emitExpiredTasks;

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -8,14 +8,12 @@
 
 
 #import <Foundation/Foundation.h>
-#import "RNFetchBlob.h"
-#import "RNFetchBlobFS.h"
 #import "RNFetchBlobNetwork.h"
+
+#import "RNFetchBlob.h"
 #import "RNFetchBlobConst.h"
-#import "RNFetchBlobReqBuilder.h"
-#import "IOS7Polyfill.h"
-#import <CommonCrypto/CommonDigest.h>
 #import "RNFetchBlobProgress.h"
+#import "RNFetchBlobRequest.h"
 
 #if __has_include(<React/RCTAssert.h>)
 #import <React/RCTRootView.h>
@@ -35,10 +33,7 @@
 //
 ////////////////////////////////////////
 
-NSMapTable * taskTable;
 NSMapTable * expirationTable;
-NSMutableDictionary * progressTable;
-NSMutableDictionary * uploadProgressTable;
 
 __attribute__((constructor))
 static void initialize_tables() {
@@ -46,91 +41,73 @@ static void initialize_tables() {
     {
         expirationTable = [[NSMapTable alloc] init];
     }
-    if(taskTable == nil)
-    {
-        taskTable = [[NSMapTable alloc] init];
-    }
-    if(progressTable == nil)
-    {
-        progressTable = [[NSMutableDictionary alloc] init];
-    }
-    if(uploadProgressTable == nil)
-    {
-        uploadProgressTable = [[NSMutableDictionary alloc] init];
-    }
 }
 
-
-typedef NS_ENUM(NSUInteger, ResponseFormat) {
-    UTF8,
-    BASE64,
-    AUTO
-};
-
-
-@interface RNFetchBlobNetwork ()
-{
-    BOOL respFile;
-    BOOL isNewPart;
-    BOOL isIncrement;
-    NSMutableData * partBuffer;
-    NSString * destPath;
-    NSOutputStream * writeStream;
-    long bodyLength;
-    NSInteger respStatus;
-    NSMutableArray * redirects;
-    ResponseFormat responseFormat;
-    BOOL followRedirect;
-    BOOL backgroundTask;
-}
-
-@end
 
 @implementation RNFetchBlobNetwork
 
 NSOperationQueue *taskQueue;
-@synthesize taskId;
-@synthesize expectedBytes;
-@synthesize receivedBytes;
-@synthesize respData;
-@synthesize callback;
-@synthesize bridge;
-@synthesize options;
-@synthesize error;
+NSMapTable<NSString*, RNFetchBlobRequest*> * requestsTable;
 
-
-// constructor
 - (id)init {
     self = [super init];
-    @synchronized ([RNFetchBlobNetwork class]) {
-        if (taskQueue == nil) {
-            taskQueue = [[NSOperationQueue alloc] init];
-            taskQueue.qualityOfService = NSQualityOfServiceUtility;
-            taskQueue.maxConcurrentOperationCount = 10;
-        }
+    if (self) {
+        requestsTable = [NSMapTable mapTableWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableWeakMemory];
+        
+        taskQueue = [[NSOperationQueue alloc] init];
+        taskQueue.qualityOfService = NSQualityOfServiceUtility;
+        taskQueue.maxConcurrentOperationCount = 10;
     }
+    
     return self;
+}
+
++ (instancetype)sharedInstance {
+    static id _sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _sharedInstance = [[self alloc] init];
+    });
+    
+    return _sharedInstance;
+}
+
++ (void) sendRequest:(__weak NSDictionary  * _Nullable )options
+       contentLength:(long) contentLength
+              bridge:(RCTBridge * _Nullable)bridgeRef
+              taskId:(NSString * _Nullable)taskId
+         withRequest:(__weak NSURLRequest * _Nullable)req
+            callback:(_Nullable RCTResponseSenderBlock) callback
+{
+    RNFetchBlobRequest *request = [[RNFetchBlobRequest alloc] init];
+    [request sendRequest:options
+           contentLength:contentLength
+                  bridge:bridgeRef
+                  taskId:taskId
+             withRequest:req
+      taskOperationQueue:taskQueue
+                callback:callback];
+    
+    @synchronized([RNFetchBlobNetwork class]) {
+        [requestsTable setObject:request forKey:taskId];
+    }
 }
 
 + (void) enableProgressReport:(NSString *) taskId config:(RNFetchBlobProgress *)config
 {
-    @synchronized ([RNFetchBlobNetwork class]) {
-        if(progressTable == nil)
-        {
-            progressTable = [[NSMutableDictionary alloc] init];
+    if (config) {
+        @synchronized ([RNFetchBlobNetwork class]) {
+            [requestsTable objectForKey:taskId].progressConfig = config;
         }
-        if (config) [progressTable setValue:config forKey:taskId];
     }
 }
 
 + (void) enableUploadProgress:(NSString *) taskId config:(RNFetchBlobProgress *)config
 {
-    @synchronized ([RNFetchBlobNetwork class]) {
-        if(uploadProgressTable == nil)
-        {
-            uploadProgressTable = [[NSMutableDictionary alloc] init];
+    if (config) {
+        @synchronized ([RNFetchBlobNetwork class]) {
+            [requestsTable objectForKey:taskId].uploadProgressConfig = config;
         }
-        if (config) [uploadProgressTable setValue:config forKey:taskId];
     }
 }
 
@@ -145,441 +122,24 @@ NSOperationQueue *taskQueue;
     return mheaders;
 }
 
-- (NSString *)md5:(NSString *)input {
-    const char* str = [input UTF8String];
-    unsigned char result[CC_MD5_DIGEST_LENGTH];
-    CC_MD5(str, (CC_LONG)strlen(str), result);
-
-    NSMutableString *ret = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH*2];
-    for(int i = 0; i<CC_MD5_DIGEST_LENGTH; i++) {
-        [ret appendFormat:@"%02x",result[i]];
-    }
-    return ret;
-}
-
-// send HTTP request
-- (void) sendRequest:(__weak NSDictionary  * _Nullable )options
-       contentLength:(long) contentLength
-              bridge:(RCTBridge * _Nullable)bridgeRef
-              taskId:(NSString * _Nullable)taskId
-         withRequest:(__weak NSURLRequest * _Nullable)req
-            callback:(_Nullable RCTResponseSenderBlock) callback
-{
-    self.taskId = taskId;
-    self.respData = [[NSMutableData alloc] initWithLength:0];
-    self.callback = callback;
-    self.bridge = bridgeRef;
-    self.expectedBytes = 0;
-    self.receivedBytes = 0;
-    self.options = options;
-    
-    backgroundTask = [options valueForKey:@"IOSBackgroundTask"] == nil ? NO : [[options valueForKey:@"IOSBackgroundTask"] boolValue];
-    followRedirect = [options valueForKey:@"followRedirect"] == nil ? YES : [[options valueForKey:@"followRedirect"] boolValue];
-    isIncrement = [options valueForKey:@"increment"] == nil ? NO : [[options valueForKey:@"increment"] boolValue];
-    redirects = [[NSMutableArray alloc] init];
-    if(req.URL != nil)
-        [redirects addObject:req.URL.absoluteString];
-
-    // set response format
-    NSString * rnfbResp = [req.allHTTPHeaderFields valueForKey:@"RNFB-Response"];
-    if([[rnfbResp lowercaseString] isEqualToString:@"base64"])
-        responseFormat = BASE64;
-    else if([[rnfbResp lowercaseString] isEqualToString:@"utf8"])
-        responseFormat = UTF8;
-    else
-        responseFormat = AUTO;
-
-    NSString * path = [self.options valueForKey:CONFIG_FILE_PATH];
-	NSString * key = [self.options valueForKey:CONFIG_KEY];
-    NSURLSession * session;
-
-    bodyLength = contentLength;
-
-    // the session trust any SSL certification
-    NSURLSessionConfiguration *defaultConfigObject;
-
-    defaultConfigObject = [NSURLSessionConfiguration defaultSessionConfiguration];
-
-    if(backgroundTask)
-    {
-        defaultConfigObject = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:taskId];
-    }
-
-    // set request timeout
-    float timeout = [options valueForKey:@"timeout"] == nil ? -1 : [[options valueForKey:@"timeout"] floatValue];
-    if(timeout > 0)
-    {
-        defaultConfigObject.timeoutIntervalForRequest = timeout/1000;
-    }
-    defaultConfigObject.HTTPMaximumConnectionsPerHost = 10;
-    session = [NSURLSession sessionWithConfiguration:defaultConfigObject delegate:self delegateQueue:taskQueue];
-    if(path != nil || [self.options valueForKey:CONFIG_USE_TEMP]!= nil)
-    {
-        respFile = YES;
-
-		NSString* cacheKey = taskId;
-		if (key != nil) {
-            cacheKey = [self md5:key];
-			if (cacheKey == nil) {
-				cacheKey = taskId;
-			}
-
-			destPath = [RNFetchBlobFS getTempPath:cacheKey withExtension:[self.options valueForKey:CONFIG_FILE_EXT]];
-            if ([[NSFileManager defaultManager] fileExistsAtPath:destPath]) {
-				callback(@[[NSNull null], RESP_TYPE_PATH, destPath]);
-                return;
-            }
-		}
-
-        if(path != nil)
-            destPath = path;
-        else
-            destPath = [RNFetchBlobFS getTempPath:cacheKey withExtension:[self.options valueForKey:CONFIG_FILE_EXT]];
-    }
-    else
-    {
-        respData = [[NSMutableData alloc] init];
-        respFile = NO;
-    }
-
-    NSURLSessionDataTask * task = [session dataTaskWithRequest:req];
-    @synchronized ([RNFetchBlobNetwork class]){
-        [taskTable setObject:task forKey:taskId];
-    }
-    [task resume];
-
-    // network status indicator
-    if([[options objectForKey:CONFIG_INDICATOR] boolValue] == YES)
-        [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
-
-}
-
 // #115 Invoke fetch.expire event on those expired requests so that the expired event can be handled
 + (void) emitExpiredTasks
 {
     @synchronized ([RNFetchBlobNetwork class]){
         NSEnumerator * emu =  [expirationTable keyEnumerator];
         NSString * key;
-
+        
         while((key = [emu nextObject]))
         {
             RCTBridge * bridge = [RNFetchBlob getRCTBridge];
             id args = @{ @"taskId": key };
             [bridge.eventDispatcher sendDeviceEventWithName:EVENT_EXPIRE body:args];
-
+            
         }
-
+        
         // clear expired task entries
         [expirationTable removeAllObjects];
         expirationTable = [[NSMapTable alloc] init];
-    }
-}
-
-////////////////////////////////////////
-//
-//  NSURLSession delegates
-//
-////////////////////////////////////////
-
-
-#pragma mark NSURLSession delegate methods
-
-
-#pragma mark - Received Response
-// set expected content length on response received
-- (void) URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
-{
-    expectedBytes = [response expectedContentLength];
-
-    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
-    NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
-    NSString * respType = @"";
-    respStatus = statusCode;
-    if ([response respondsToSelector:@selector(allHeaderFields)])
-    {
-        NSDictionary *headers = [httpResponse allHeaderFields];
-        NSString * respCType = [[RNFetchBlobReqBuilder getHeaderIgnoreCases:@"Content-Type" fromHeaders:headers] lowercaseString];
-        if(self.isServerPush == NO)
-        {
-            self.isServerPush = [[respCType lowercaseString] RNFBContainsString:@"multipart/x-mixed-replace;"];
-        }
-        if(self.isServerPush)
-        {
-            if(partBuffer != nil)
-            {
-                [self.bridge.eventDispatcher
-                 sendDeviceEventWithName:EVENT_SERVER_PUSH
-                 body:@{
-                        @"taskId": taskId,
-                        @"chunk": [partBuffer base64EncodedStringWithOptions:0],
-                        }
-                 ];
-            }
-            partBuffer = [[NSMutableData alloc] init];
-            completionHandler(NSURLSessionResponseAllow);
-            return;
-        }
-        if(respCType != nil)
-        {
-            NSArray * extraBlobCTypes = [options objectForKey:CONFIG_EXTRA_BLOB_CTYPE];
-            if([respCType RNFBContainsString:@"text/"])
-            {
-                respType = @"text";
-            }
-            else if([respCType RNFBContainsString:@"application/json"])
-            {
-                respType = @"json";
-            }
-            // If extra blob content type is not empty, check if response type matches
-            else if( extraBlobCTypes !=  nil) {
-                for(NSString * substr in extraBlobCTypes)
-                {
-                    if([respCType RNFBContainsString:[substr lowercaseString]])
-                    {
-                        respType = @"blob";
-                        respFile = YES;
-                        destPath = [RNFetchBlobFS getTempPath:taskId withExtension:nil];
-                        break;
-                    }
-                }
-            }
-            else
-            {
-                respType = @"blob";
-                // for XMLHttpRequest, switch response data handling strategy automatically
-                if([options valueForKey:@"auto"]) {
-                    respFile = YES;
-                    destPath = [RNFetchBlobFS getTempPath:taskId withExtension:@""];
-                }
-            }
-        } else {
-            respType = @"text";
-        }
-
-#pragma mark - handling cookies
-        // # 153 get cookies
-        if(response.URL != nil)
-        {
-            NSHTTPCookieStorage * cookieStore = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-            NSArray<NSHTTPCookie *> * cookies = [NSHTTPCookie cookiesWithResponseHeaderFields: headers forURL:response.URL];
-            if(cookies != nil && [cookies count] > 0) {
-                [cookieStore setCookies:cookies forURL:response.URL mainDocumentURL:nil];
-            }
-        }
-
-        [self.bridge.eventDispatcher
-         sendDeviceEventWithName: EVENT_STATE_CHANGE
-         body:@{
-                @"taskId": taskId,
-                @"state": @"2",
-                @"headers": headers,
-                @"redirects": redirects,
-                @"respType" : respType,
-                @"timeout" : @NO,
-                @"status": [NSNumber numberWithInteger:statusCode]
-                }
-        ];
-    }
-    else
-        NSLog(@"oops");
-
-    if(respFile == YES)
-    {
-        @try{
-            NSFileManager * fm = [NSFileManager defaultManager];
-            NSString * folder = [destPath stringByDeletingLastPathComponent];
-            if(![fm fileExistsAtPath:folder])
-            {
-                [fm createDirectoryAtPath:folder withIntermediateDirectories:YES attributes:NULL error:nil];
-            }
-            BOOL overwrite = [options valueForKey:@"overwrite"] == nil ? YES : [[options valueForKey:@"overwrite"] boolValue];
-            BOOL appendToExistingFile = [destPath RNFBContainsString:@"?append=true"];
-
-            appendToExistingFile = !overwrite;
-
-            // For solving #141 append response data if the file already exists
-            // base on PR#139 @kejinliang
-            if(appendToExistingFile)
-            {
-                destPath = [destPath stringByReplacingOccurrencesOfString:@"?append=true" withString:@""];
-            }
-            if (![fm fileExistsAtPath:destPath])
-            {
-                [fm createFileAtPath:destPath contents:[[NSData alloc] init] attributes:nil];
-            }
-            writeStream = [[NSOutputStream alloc] initToFileAtPath:destPath append:appendToExistingFile];
-            [writeStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
-            [writeStream open];
-        }
-        @catch(NSException * ex)
-        {
-            NSLog(@"write file error");
-        }
-    }
-
-    completionHandler(NSURLSessionResponseAllow);
-}
-
-
-// download progress handler
-- (void) URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
-{
-    // For #143 handling multipart/x-mixed-replace response
-    if(self.isServerPush)
-    {
-        [partBuffer appendData:data];
-        return ;
-    }
-
-    NSNumber * received = [NSNumber numberWithLong:[data length]];
-    receivedBytes += [received longValue];
-    NSString * chunkString = @"";
-
-    if(isIncrement == YES)
-    {
-        chunkString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    }
-
-    if(respFile == NO)
-    {
-        [respData appendData:data];
-    }
-    else
-    {
-        [writeStream write:[data bytes] maxLength:[data length]];
-    }
-    
-    if(expectedBytes == 0)
-        return;
-    
-    RNFetchBlobProgress * pconfig;
-    
-    @synchronized ([RNFetchBlobNetwork class]){
-        pconfig = [progressTable valueForKey:taskId];
-    }
-        
-    NSNumber * now =[NSNumber numberWithFloat:((float)receivedBytes/(float)expectedBytes)];
-    
-    if(pconfig != nil && [pconfig shouldReport:now])
-    {
-        [self.bridge.eventDispatcher
-         sendDeviceEventWithName:EVENT_PROGRESS
-         body:@{
-                @"taskId": taskId,
-                @"written": [NSString stringWithFormat:@"%ld", (long) receivedBytes],
-                @"total": [NSString stringWithFormat:@"%ld", (long) expectedBytes],
-                @"chunk": chunkString
-                }
-         ];
-    }
-}
-
-- (void) URLSession:(NSURLSession *)session didBecomeInvalidWithError:(nullable NSError *)error
-{
-    if([session isEqual:session])
-        session = nil;
-}
-
-
-- (void) URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
-{
-
-    self.error = error;
-    NSString * errMsg;
-    NSString * respStr;
-    NSString * rnfbRespType;
-
-    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
-
-    if(error != nil)
-    {
-        errMsg = [error localizedDescription];
-    }
-
-    if(respFile == YES)
-    {
-        [writeStream close];
-        rnfbRespType = RESP_TYPE_PATH;
-        respStr = destPath;
-    }
-    // base64 response
-    else {
-        // #73 fix unicode data encoding issue :
-        // when response type is BASE64, we should first try to encode the response data to UTF8 format
-        // if it turns out not to be `nil` that means the response data contains valid UTF8 string,
-        // in order to properly encode the UTF8 string, use URL encoding before BASE64 encoding.
-        NSString * utf8 = [[NSString alloc] initWithData:respData encoding:NSUTF8StringEncoding];
-
-        if(responseFormat == BASE64)
-        {
-            rnfbRespType = RESP_TYPE_BASE64;
-            respStr = [respData base64EncodedStringWithOptions:0];
-        }
-        else if (responseFormat == UTF8)
-        {
-            rnfbRespType = RESP_TYPE_UTF8;
-            respStr = utf8;
-        }
-        else
-        {
-            if(utf8 != nil)
-            {
-                rnfbRespType = RESP_TYPE_UTF8;
-                respStr = utf8;
-            }
-            else
-            {
-                rnfbRespType = RESP_TYPE_BASE64;
-                respStr = [respData base64EncodedStringWithOptions:0];
-            }
-        }
-    }
-
-
-    callback(@[
-               errMsg ?: [NSNull null],
-               rnfbRespType ?: @"",
-               respStr ?: [NSNull null]
-               ]);
-
-    @synchronized ([RNFetchBlobNetwork class])
-    {
-        if([taskTable objectForKey:taskId] == nil)
-            NSLog(@"object released by ARC.");
-        else
-            [taskTable removeObjectForKey:taskId];
-        [uploadProgressTable removeObjectForKey:taskId];
-        [progressTable removeObjectForKey:taskId];
-    }
-
-    respData = nil;
-    receivedBytes = 0;
-    [session finishTasksAndInvalidate];
-
-}
-
-// upload progress handler
-- (void) URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesWritten totalBytesExpectedToSend:(int64_t)totalBytesExpectedToWrite
-{
-    if(totalBytesExpectedToWrite == 0)
-        return;
-    
-    RNFetchBlobProgress * pconfig;
-    
-    @synchronized ([RNFetchBlobNetwork class]) {
-        pconfig = [uploadProgressTable valueForKey:taskId];
-    }
-    
-    NSNumber * now = [NSNumber numberWithFloat:((float)totalBytesWritten/(float)totalBytesExpectedToWrite)];
-    if(pconfig != nil && [pconfig shouldReport:now]) {
-        [self.bridge.eventDispatcher
-         sendDeviceEventWithName:EVENT_PROGRESS_UPLOAD
-         body:@{
-                @"taskId": taskId,
-                @"written": [NSString stringWithFormat:@"%ld", (long) totalBytesWritten],
-                @"total": [NSString stringWithFormat:@"%ld", (long) totalBytesExpectedToWrite]
-                }
-         ];
     }
 }
 
@@ -588,45 +148,11 @@ NSOperationQueue *taskQueue;
     NSURLSessionDataTask * task;
     
     @synchronized ([RNFetchBlobNetwork class]) {
-        task = [taskTable objectForKey:taskId];
+        task = [requestsTable objectForKey:taskId].task;
     }
     
-    if(task != nil && task.state == NSURLSessionTaskStateRunning)
+    if(task && task.state == NSURLSessionTaskStateRunning) {
         [task cancel];
-}
-
-
-- (void) URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable credantial))completionHandler
-{
-    BOOL trusty = [[options valueForKey:CONFIG_TRUSTY] boolValue];
-    if(!trusty)
-    {
-        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
-    }
-    else
-    {
-        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
-    }
-}
-
-
-- (void) URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session
-{
-    NSLog(@"sess done in background");
-}
-
-- (void) URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler
-{
-
-    if(followRedirect)
-    {
-        if(request.URL != nil)
-            [redirects addObject:[request.URL absoluteString]];
-        completionHandler(request);
-    }
-    else
-    {
-        completionHandler(nil);
     }
 }
 

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -36,8 +36,7 @@ NSMapTable * expirationTable;
 
 __attribute__((constructor))
 static void initialize_tables() {
-    if(expirationTable == nil)
-    {
+    if (expirationTable == nil) {
         expirationTable = [[NSMapTable alloc] init];
     }
 }
@@ -62,6 +61,7 @@ static void initialize_tables() {
 + (RNFetchBlobNetwork* _Nullable)sharedInstance {
     static id _sharedInstance = nil;
     static dispatch_once_t onceToken;
+
     dispatch_once(&onceToken, ^{
         _sharedInstance = [[self alloc] init];
     });
@@ -116,7 +116,7 @@ static void initialize_tables() {
         task = [self.requestsTable objectForKey:taskId].task;
     }
     
-    if(task && task.state == NSURLSessionTaskStateRunning) {
+    if (task && task.state == NSURLSessionTaskStateRunning) {
         [task cancel];
     }
 }
@@ -125,7 +125,7 @@ static void initialize_tables() {
 + (NSMutableDictionary *) normalizeHeaders:(NSDictionary *)headers
 {
     NSMutableDictionary * mheaders = [[NSMutableDictionary alloc]init];
-    for(NSString * key in headers) {
+    for (NSString * key in headers) {
         [mheaders setValue:[headers valueForKey:key] forKey:[key lowercaseString]];
     }
     
@@ -139,7 +139,7 @@ static void initialize_tables() {
         NSEnumerator * emu =  [expirationTable keyEnumerator];
         NSString * key;
         
-        while((key = [emu nextObject]))
+        while ((key = [emu nextObject]))
         {
             RCTBridge * bridge = [RNFetchBlob getRCTBridge];
             id args = @{ @"taskId": key };

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -137,7 +137,6 @@ NSOperationQueue *taskQueue;
 // removing case from headers
 + (NSMutableDictionary *) normalizeHeaders:(NSDictionary *)headers
 {
-
     NSMutableDictionary * mheaders = [[NSMutableDictionary alloc]init];
     for(NSString * key in headers) {
         [mheaders setValue:[headers valueForKey:key] forKey:[key lowercaseString]];

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -105,6 +105,7 @@ NSOperationQueue *taskQueue;
     @synchronized ([RNFetchBlobNetwork class]) {
         if (taskQueue == nil) {
             taskQueue = [[NSOperationQueue alloc] init];
+            taskQueue.qualityOfService = NSQualityOfServiceUtility;
             taskQueue.maxConcurrentOperationCount = 10;
         }
     }

--- a/ios/RNFetchBlobReqBuilder.h
+++ b/ios/RNFetchBlobReqBuilder.h
@@ -29,7 +29,7 @@
                      body:(NSString *)body
                onComplete:(void(^)(NSURLRequest * req, long bodyLength))onComplete;
 
-+(NSString *) getHeaderIgnoreCases:(NSString *)field fromHeaders:(NSMutableArray *) headers;
++(NSString *) getHeaderIgnoreCases:(NSString *)field fromHeaders:(NSDictionary *) headers;
 
 
 @end

--- a/ios/RNFetchBlobReqBuilder.m
+++ b/ios/RNFetchBlobReqBuilder.m
@@ -277,7 +277,7 @@
     }
 }
 
-+(NSString *) getHeaderIgnoreCases:(NSString *)field fromHeaders:(NSMutableDictionary *) headers {
++(NSString *) getHeaderIgnoreCases:(NSString *)field fromHeaders:(NSDictionary *) headers {
 
     NSString * normalCase = [headers valueForKey:field];
     NSString * ignoredCase = [headers valueForKey:[field lowercaseString]];

--- a/ios/RNFetchBlobRequest.h
+++ b/ios/RNFetchBlobRequest.h
@@ -1,0 +1,47 @@
+//
+//  RNFetchBlobRequest.h
+//  RNFetchBlob
+//
+//  Created by Artur Chrusciel on 15.01.18.
+//  Copyright © 2018 wkh237.github.io. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "RNFetchBlobProgress.h"
+
+#if __has_include(<React/RCTAssert.h>)
+#import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
+#endif
+
+#ifndef RNFetchBlobRequest_h
+#define RNFetchBlobRequest_h
+
+@interface RNFetchBlobRequest : NSObject <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
+
+@property (nullable, nonatomic) NSString * taskId;
+@property (nonatomic) long long expectedBytes;
+@property (nonatomic) long long receivedBytes;
+@property (nonatomic) BOOL isServerPush;
+@property (nullable, nonatomic) NSMutableData * respData;
+@property (nullable, strong, nonatomic) RCTResponseSenderBlock callback;
+@property (nullable, nonatomic) RCTBridge * bridge;
+@property (nullable, nonatomic) NSDictionary * options;
+@property (nullable, nonatomic) NSError * error;
+@property (nullable, nonatomic) RNFetchBlobProgress *progressConfig;
+@property (nullable, nonatomic) RNFetchBlobProgress *uploadProgressConfig;
+@property (nullable, nonatomic, weak) NSURLSessionDataTask *task;
+
+- (void) sendRequest:(NSDictionary  * _Nullable )options
+       contentLength:(long)contentLength
+              bridge:(RCTBridge * _Nullable)bridgeRef
+              taskId:(NSString * _Nullable)taskId
+         withRequest:(NSURLRequest * _Nullable)req
+  taskOperationQueue:(NSOperationQueue * _Nonnull)operationQueue
+            callback:(_Nullable RCTResponseSenderBlock) callback;
+
+@end
+
+#endif /* RNFetchBlobRequest_h */

--- a/ios/RNFetchBlobRequest.h
+++ b/ios/RNFetchBlobRequest.h
@@ -6,6 +6,9 @@
 //  Copyright © 2018 wkh237.github.io. All rights reserved.
 //
 
+#ifndef RNFetchBlobRequest_h
+#define RNFetchBlobRequest_h
+
 #import <Foundation/Foundation.h>
 
 #import "RNFetchBlobProgress.h"
@@ -15,9 +18,6 @@
 #else
 #import "RCTBridgeModule.h"
 #endif
-
-#ifndef RNFetchBlobRequest_h
-#define RNFetchBlobRequest_h
 
 @interface RNFetchBlobRequest : NSObject <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
 

--- a/ios/RNFetchBlobRequest.m
+++ b/ios/RNFetchBlobRequest.m
@@ -419,16 +419,6 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
                rnfbRespType ?: @"",
                respStr ?: [NSNull null]
                ]);
-    /*
-    @synchronized ([RNFetchBlobNetwork class])
-    {
-        if([taskTable objectForKey:taskId] == nil)
-            NSLog(@"object released by ARC.");
-        else
-            [taskTable removeObjectForKey:taskId];
-        [uploadProgressTable removeObjectForKey:taskId];
-        [progressTable removeObjectForKey:taskId];
-    }*/
     
     respData = nil;
     receivedBytes = 0;

--- a/ios/RNFetchBlobRequest.m
+++ b/ios/RNFetchBlobRequest.m
@@ -1,0 +1,495 @@
+//
+//  RNFetchBlobRequest.m
+//  RNFetchBlob
+//
+//  Created by Artur Chrusciel on 15.01.18.
+//  Copyright © 2018 wkh237.github.io. All rights reserved.
+//
+
+#import "RNFetchBlobRequest.h"
+
+#import "RNFetchBlobFS.h"
+#import "RNFetchBlobConst.h"
+#import "RNFetchBlobReqBuilder.h"
+
+#import "IOS7Polyfill.h"
+#import <CommonCrypto/CommonDigest.h>
+
+
+typedef NS_ENUM(NSUInteger, ResponseFormat) {
+    UTF8,
+    BASE64,
+    AUTO
+};
+
+@interface RNFetchBlobRequest ()
+{
+    BOOL respFile;
+    BOOL isNewPart;
+    BOOL isIncrement;
+    NSMutableData * partBuffer;
+    NSString * destPath;
+    NSOutputStream * writeStream;
+    long bodyLength;
+    NSInteger respStatus;
+    NSMutableArray * redirects;
+    ResponseFormat responseFormat;
+    BOOL followRedirect;
+    BOOL backgroundTask;
+}
+
+@end
+
+@implementation RNFetchBlobRequest
+
+@synthesize taskId;
+@synthesize expectedBytes;
+@synthesize receivedBytes;
+@synthesize respData;
+@synthesize callback;
+@synthesize bridge;
+@synthesize options;
+@synthesize error;
+
+
+- (NSString *)md5:(NSString *)input {
+    const char* str = [input UTF8String];
+    unsigned char result[CC_MD5_DIGEST_LENGTH];
+    CC_MD5(str, (CC_LONG)strlen(str), result);
+    
+    NSMutableString *ret = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH*2];
+    for(int i = 0; i<CC_MD5_DIGEST_LENGTH; i++) {
+        [ret appendFormat:@"%02x",result[i]];
+    }
+    return ret;
+}
+
+// send HTTP request
+- (void) sendRequest:(__weak NSDictionary  * _Nullable )options
+       contentLength:(long) contentLength
+              bridge:(RCTBridge * _Nullable)bridgeRef
+              taskId:(NSString * _Nullable)taskId
+         withRequest:(__weak NSURLRequest * _Nullable)req
+  taskOperationQueue:(NSOperationQueue * _Nonnull)operationQueue
+            callback:(_Nullable RCTResponseSenderBlock) callback
+{
+    self.taskId = taskId;
+    self.respData = [[NSMutableData alloc] initWithLength:0];
+    self.callback = callback;
+    self.bridge = bridgeRef;
+    self.expectedBytes = 0;
+    self.receivedBytes = 0;
+    self.options = options;
+    
+    backgroundTask = [options valueForKey:@"IOSBackgroundTask"] == nil ? NO : [[options valueForKey:@"IOSBackgroundTask"] boolValue];
+    followRedirect = [options valueForKey:@"followRedirect"] == nil ? YES : [[options valueForKey:@"followRedirect"] boolValue];
+    isIncrement = [options valueForKey:@"increment"] == nil ? NO : [[options valueForKey:@"increment"] boolValue];
+    redirects = [[NSMutableArray alloc] init];
+    if(req.URL != nil)
+        [redirects addObject:req.URL.absoluteString];
+    
+    // set response format
+    NSString * rnfbResp = [req.allHTTPHeaderFields valueForKey:@"RNFB-Response"];
+    if([[rnfbResp lowercaseString] isEqualToString:@"base64"])
+        responseFormat = BASE64;
+    else if([[rnfbResp lowercaseString] isEqualToString:@"utf8"])
+        responseFormat = UTF8;
+    else
+        responseFormat = AUTO;
+    
+    NSString * path = [self.options valueForKey:CONFIG_FILE_PATH];
+    NSString * key = [self.options valueForKey:CONFIG_KEY];
+    NSURLSession * session;
+    
+    bodyLength = contentLength;
+    
+    // the session trust any SSL certification
+    NSURLSessionConfiguration *defaultConfigObject;
+    
+    defaultConfigObject = [NSURLSessionConfiguration defaultSessionConfiguration];
+    
+    if(backgroundTask)
+    {
+        defaultConfigObject = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:taskId];
+    }
+    
+    // set request timeout
+    float timeout = [options valueForKey:@"timeout"] == nil ? -1 : [[options valueForKey:@"timeout"] floatValue];
+    if(timeout > 0)
+    {
+        defaultConfigObject.timeoutIntervalForRequest = timeout/1000;
+    }
+    defaultConfigObject.HTTPMaximumConnectionsPerHost = 10;
+    session = [NSURLSession sessionWithConfiguration:defaultConfigObject delegate:self delegateQueue:operationQueue];
+    if(path != nil || [self.options valueForKey:CONFIG_USE_TEMP]!= nil)
+    {
+        respFile = YES;
+        
+        NSString* cacheKey = taskId;
+        if (key != nil) {
+            cacheKey = [self md5:key];
+            if (cacheKey == nil) {
+                cacheKey = taskId;
+            }
+            
+            destPath = [RNFetchBlobFS getTempPath:cacheKey withExtension:[self.options valueForKey:CONFIG_FILE_EXT]];
+            if ([[NSFileManager defaultManager] fileExistsAtPath:destPath]) {
+                callback(@[[NSNull null], RESP_TYPE_PATH, destPath]);
+                return;
+            }
+        }
+        
+        if(path != nil)
+            destPath = path;
+        else
+            destPath = [RNFetchBlobFS getTempPath:cacheKey withExtension:[self.options valueForKey:CONFIG_FILE_EXT]];
+    }
+    else
+    {
+        respData = [[NSMutableData alloc] init];
+        respFile = NO;
+    }
+    
+    self.task = [session dataTaskWithRequest:req];
+    [self.task resume];
+    
+    // network status indicator
+    if([[options objectForKey:CONFIG_INDICATOR] boolValue] == YES)
+        [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+    
+}
+
+////////////////////////////////////////
+//
+//  NSURLSession delegates
+//
+////////////////////////////////////////
+
+
+#pragma mark NSURLSession delegate methods
+
+
+#pragma mark - Received Response
+// set expected content length on response received
+- (void) URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
+{
+    expectedBytes = [response expectedContentLength];
+    
+    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
+    NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+    NSString * respType = @"";
+    respStatus = statusCode;
+    if ([response respondsToSelector:@selector(allHeaderFields)])
+    {
+        NSDictionary *headers = [httpResponse allHeaderFields];
+        NSString * respCType = [[RNFetchBlobReqBuilder getHeaderIgnoreCases:@"Content-Type" fromHeaders:headers] lowercaseString];
+        if(self.isServerPush == NO)
+        {
+            self.isServerPush = [[respCType lowercaseString] RNFBContainsString:@"multipart/x-mixed-replace;"];
+        }
+        if(self.isServerPush)
+        {
+            if(partBuffer != nil)
+            {
+                [self.bridge.eventDispatcher
+                 sendDeviceEventWithName:EVENT_SERVER_PUSH
+                 body:@{
+                        @"taskId": taskId,
+                        @"chunk": [partBuffer base64EncodedStringWithOptions:0],
+                        }
+                 ];
+            }
+            partBuffer = [[NSMutableData alloc] init];
+            completionHandler(NSURLSessionResponseAllow);
+            return;
+        }
+        if(respCType != nil)
+        {
+            NSArray * extraBlobCTypes = [options objectForKey:CONFIG_EXTRA_BLOB_CTYPE];
+            if([respCType RNFBContainsString:@"text/"])
+            {
+                respType = @"text";
+            }
+            else if([respCType RNFBContainsString:@"application/json"])
+            {
+                respType = @"json";
+            }
+            // If extra blob content type is not empty, check if response type matches
+            else if( extraBlobCTypes !=  nil) {
+                for(NSString * substr in extraBlobCTypes)
+                {
+                    if([respCType RNFBContainsString:[substr lowercaseString]])
+                    {
+                        respType = @"blob";
+                        respFile = YES;
+                        destPath = [RNFetchBlobFS getTempPath:taskId withExtension:nil];
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                respType = @"blob";
+                // for XMLHttpRequest, switch response data handling strategy automatically
+                if([options valueForKey:@"auto"]) {
+                    respFile = YES;
+                    destPath = [RNFetchBlobFS getTempPath:taskId withExtension:@""];
+                }
+            }
+        } else {
+            respType = @"text";
+        }
+        
+#pragma mark - handling cookies
+        // # 153 get cookies
+        if(response.URL != nil)
+        {
+            NSHTTPCookieStorage * cookieStore = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+            NSArray<NSHTTPCookie *> * cookies = [NSHTTPCookie cookiesWithResponseHeaderFields: headers forURL:response.URL];
+            if(cookies != nil && [cookies count] > 0) {
+                [cookieStore setCookies:cookies forURL:response.URL mainDocumentURL:nil];
+            }
+        }
+        
+        [self.bridge.eventDispatcher
+         sendDeviceEventWithName: EVENT_STATE_CHANGE
+         body:@{
+                @"taskId": taskId,
+                @"state": @"2",
+                @"headers": headers,
+                @"redirects": redirects,
+                @"respType" : respType,
+                @"timeout" : @NO,
+                @"status": [NSNumber numberWithInteger:statusCode]
+                }
+         ];
+    }
+    else
+        NSLog(@"oops");
+    
+    if(respFile == YES)
+    {
+        @try{
+            NSFileManager * fm = [NSFileManager defaultManager];
+            NSString * folder = [destPath stringByDeletingLastPathComponent];
+            if(![fm fileExistsAtPath:folder])
+            {
+                [fm createDirectoryAtPath:folder withIntermediateDirectories:YES attributes:NULL error:nil];
+            }
+            BOOL overwrite = [options valueForKey:@"overwrite"] == nil ? YES : [[options valueForKey:@"overwrite"] boolValue];
+            BOOL appendToExistingFile = [destPath RNFBContainsString:@"?append=true"];
+            
+            appendToExistingFile = !overwrite;
+            
+            // For solving #141 append response data if the file already exists
+            // base on PR#139 @kejinliang
+            if(appendToExistingFile)
+            {
+                destPath = [destPath stringByReplacingOccurrencesOfString:@"?append=true" withString:@""];
+            }
+            if (![fm fileExistsAtPath:destPath])
+            {
+                [fm createFileAtPath:destPath contents:[[NSData alloc] init] attributes:nil];
+            }
+            writeStream = [[NSOutputStream alloc] initToFileAtPath:destPath append:appendToExistingFile];
+            [writeStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+            [writeStream open];
+        }
+        @catch(NSException * ex)
+        {
+            NSLog(@"write file error");
+        }
+    }
+    
+    completionHandler(NSURLSessionResponseAllow);
+}
+
+
+// download progress handler
+- (void) URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
+{
+    // For #143 handling multipart/x-mixed-replace response
+    if(self.isServerPush)
+    {
+        [partBuffer appendData:data];
+        return ;
+    }
+    
+    NSNumber * received = [NSNumber numberWithLong:[data length]];
+    receivedBytes += [received longValue];
+    NSString * chunkString = @"";
+    
+    if(isIncrement == YES)
+    {
+        chunkString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    }
+    
+    if(respFile == NO)
+    {
+        [respData appendData:data];
+    }
+    else
+    {
+        [writeStream write:[data bytes] maxLength:[data length]];
+    }
+    
+    if(expectedBytes == 0)
+        return;
+    
+    NSNumber * now =[NSNumber numberWithFloat:((float)receivedBytes/(float)expectedBytes)];
+    
+    if([self.progressConfig shouldReport:now])
+    {
+        [self.bridge.eventDispatcher
+         sendDeviceEventWithName:EVENT_PROGRESS
+         body:@{
+                @"taskId": taskId,
+                @"written": [NSString stringWithFormat:@"%ld", (long) receivedBytes],
+                @"total": [NSString stringWithFormat:@"%ld", (long) expectedBytes],
+                @"chunk": chunkString
+                }
+         ];
+    }
+}
+
+- (void) URLSession:(NSURLSession *)session didBecomeInvalidWithError:(nullable NSError *)error
+{
+    if([session isEqual:session])
+        session = nil;
+}
+
+
+- (void) URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+{
+    
+    self.error = error;
+    NSString * errMsg;
+    NSString * respStr;
+    NSString * rnfbRespType;
+    
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    
+    if(error != nil)
+    {
+        errMsg = [error localizedDescription];
+    }
+    
+    if(respFile == YES)
+    {
+        [writeStream close];
+        rnfbRespType = RESP_TYPE_PATH;
+        respStr = destPath;
+    }
+    // base64 response
+    else {
+        // #73 fix unicode data encoding issue :
+        // when response type is BASE64, we should first try to encode the response data to UTF8 format
+        // if it turns out not to be `nil` that means the response data contains valid UTF8 string,
+        // in order to properly encode the UTF8 string, use URL encoding before BASE64 encoding.
+        NSString * utf8 = [[NSString alloc] initWithData:respData encoding:NSUTF8StringEncoding];
+        
+        if(responseFormat == BASE64)
+        {
+            rnfbRespType = RESP_TYPE_BASE64;
+            respStr = [respData base64EncodedStringWithOptions:0];
+        }
+        else if (responseFormat == UTF8)
+        {
+            rnfbRespType = RESP_TYPE_UTF8;
+            respStr = utf8;
+        }
+        else
+        {
+            if(utf8 != nil)
+            {
+                rnfbRespType = RESP_TYPE_UTF8;
+                respStr = utf8;
+            }
+            else
+            {
+                rnfbRespType = RESP_TYPE_BASE64;
+                respStr = [respData base64EncodedStringWithOptions:0];
+            }
+        }
+    }
+    
+    
+    callback(@[
+               errMsg ?: [NSNull null],
+               rnfbRespType ?: @"",
+               respStr ?: [NSNull null]
+               ]);
+    /*
+    @synchronized ([RNFetchBlobNetwork class])
+    {
+        if([taskTable objectForKey:taskId] == nil)
+            NSLog(@"object released by ARC.");
+        else
+            [taskTable removeObjectForKey:taskId];
+        [uploadProgressTable removeObjectForKey:taskId];
+        [progressTable removeObjectForKey:taskId];
+    }*/
+    
+    respData = nil;
+    receivedBytes = 0;
+    [session finishTasksAndInvalidate];
+    
+}
+
+// upload progress handler
+- (void) URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesWritten totalBytesExpectedToSend:(int64_t)totalBytesExpectedToWrite
+{
+    if(totalBytesExpectedToWrite == 0)
+        return;
+    
+    NSNumber * now = [NSNumber numberWithFloat:((float)totalBytesWritten/(float)totalBytesExpectedToWrite)];
+
+    if([self.uploadProgressConfig shouldReport:now]) {
+        [self.bridge.eventDispatcher
+         sendDeviceEventWithName:EVENT_PROGRESS_UPLOAD
+         body:@{
+                @"taskId": taskId,
+                @"written": [NSString stringWithFormat:@"%ld", (long) totalBytesWritten],
+                @"total": [NSString stringWithFormat:@"%ld", (long) totalBytesExpectedToWrite]
+                }
+         ];
+    }
+}
+
+
+- (void) URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable credantial))completionHandler
+{
+    BOOL trusty = [[options valueForKey:CONFIG_TRUSTY] boolValue];
+    if(!trusty)
+    {
+        completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+    }
+    else
+    {
+        completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
+    }
+}
+
+
+- (void) URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session
+{
+    NSLog(@"sess done in background");
+}
+
+- (void) URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler
+{
+    
+    if(followRedirect)
+    {
+        if(request.URL != nil)
+            [redirects addObject:[request.URL absoluteString]];
+        completionHandler(request);
+    }
+    else
+    {
+        completionHandler(nil);
+    }
+}
+
+
+@end


### PR DESCRIPTION
COPY OF: https://github.com/wkh237/react-native-fetch-blob/pull/636

Respond if I should still make it to 0.10.9 branch.

Hi,

this PR came from crashes we still get (some description):
https://github.com/wcandillon/react-native-img-cache/issues/95

...but evolved.

Whole RNFetchBlobNetwork class actually do two things:
- keeping tasks references to cancel them, change their progress config etc.,
- session and requests logic.

I moved session and requests logic into separate file, now it's more clean what do what.
```NSMapTable``` seemed to be used incorrectly or just it's (weak) features not used (it seems from log ```NSLog(@"object released by ARC.");``` that it should or was used), anyway, it's now instantiated with ```NSMapTableWeakMemory``` option for objects, so requests will be released, default in NSMapTable is to use strong references.

```sharedInstance``` is used instead tables and dictionaries instances created on load. This pattern is used all around but please give me a feedback why previous is better solution, maybe I missed something.

Other things done in this PR when implementing:
- ```checkExpiredSessions``` didn’t find anywhere, removed from header
- __block storage type not needed, variables not used in blocks in scope
- extern storage type not used in .m files
- nullability type in RNFetchBlobNetwork, should be checked and applied for method arguments in other classes
- unimplemented ```+ (void) enableProgressReport:(NSString *) taskId, + (void) enableUploadProgress:(NSString *) taskId, - (void) sendRequest``` method declarations removed
unused ```fileTaskCompletionHandler``` and ```dataTaskCompletionHandler``` properties and synthesizers removed
- other small warning messages fixes
- every single request is created on new RNFetchBlobNetwork instance so taskQueue.maxConcurrentOperationCount seems not work as expected -> made taskQueue instantiated per RNFetchBlobNetwork instance.

I can't find any place where actually something is added to ```expirationTable```.

Does ```HTTPMaximumConnectionsPerHost = 10``` have any impact as new session is created for every request (except ```defaultSessionConfiguration```)? In docs it says that it applies to all sessions ```'...based on this configuration'```, what actually this means, the same instance, identifier or some comparison???

I'm aware of few fixes that are in 0.10.9 not included here.

TODO:
- subclass RCTEventEmitter to send events
- expired task logic?

This is WIP, works for now for us, but didn't test everything and any feedback or testing would be great.


POST 16.01.2018

What about applying:
http://google.github.io/styleguide/objcguide.html
I agree with that code guideline mostly.


POST 19.01.2018:

https://github.com/flatfox-ag/react-native-fetch-blob/tree/exception_fixes 2 days already in production, no exceptions yet.

This branch have all these fixes:
https://github.com/wkh237/react-native-fetch-blob/pull/619
https://github.com/wkh237/react-native-fetch-blob/pull/499

and all changes from:
https://github.com/flatfox-ag/react-native-fetch-blob/tree/synchronized

DOES NOT HAVE ```wkh237:0.11.0``` commits listed in this PR!

feel free to:
```"react-native-fetch-blob": "github:flatfox-ag/react-native-fetch-blob#exception_fixes",```

As we use it in production I removed WIP note.
Stuff in TODO will come in different PRs I guess.

POST 25.01.2018

Week without crashes on production, fixes confirmed :)
