### PR TITLE
Synchronized tables, separated requests and network logic and other...

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,5 @@
 Thank you for making a pull request ! Just a gentle reminder :)
 
 1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
-2. Bug fix request to "Bug Fix Branch" 0.10.6
+2. Bug fix request to "Bug Fix Branch" 0.10.7
 3. Correct README.md can directly to master

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,5 @@
 Thank you for making a pull request ! Just a gentle reminder :)
 
 1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
-2. Bug fix request to "Bug Fix Branch" 0.10.8
+2. Bug fix request to "Bug Fix Branch" 0.10.9
 3. Correct README.md can directly to master

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,5 @@
 Thank you for making a pull request ! Just a gentle reminder :)
 
 1. If the PR is offering a feature please make the request to our "Feature Branch" 0.11.0
-2. Bug fix request to "Bug Fix Branch" 0.10.7
+2. Bug fix request to "Bug Fix Branch" 0.10.8
 3. Correct README.md can directly to master

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,7 +1,10 @@
 960px <pinovel@gmail.com>
+Amerrnath <amerrnath.21@gmail.com>
 Andreas Amsenius <andreas@amsenius.se>
 Andrew Jack <me@andrewjack.uk>
 Arthur Ouaki <arthur.ouaki@gmail.com>
+Ben <benhsieh@catchplay.com>
+Ben Hsieh <benhsieh@catchplay.com>
 Binur Konarbai <binur95@gmail.com>
 Bronco <heybronco@gmail.com>
 Chris Sloey <chris@addjam.com>
@@ -12,6 +15,8 @@ Erik Smartt <code@eriksmartt.com>
 Evgeniy Baraniuk <ev.baraniuk@gmail.com>
 Frank van der Hoek <frank.vanderhoek@gmail.com>
 Guy Blank <blank.guy@gmail.com>
+Jacob Lauritzen <jacsebl@hotmail.com>
+Jeremi Stadler <stadler.jeremi@gmail.com>
 Jon San Miguel <sanmiguelje@gmail.com>
 Juan B. Rodriguez <jbrodriguez@gmail.com>
 Kaishley <kklingachetti@msn.com>
@@ -24,6 +29,7 @@ Nick Pomfret <npomfret@users.noreply.github.com>
 Oliver <spendabuk@hotmail.com>
 Petter Hesselberg <petterh@microsoft.com>
 Reza Ghorbani <r.ghorbani.f@gmail.com>
+Simón Gómez <simongomez95@gmail.com>
 Steve Liles <steveliles@gmail.com>
 Tim Suchanek <tim.suchanek@gmail.com>
 Yonsh Lin <yonsh@live.com>

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ RNFetchBlob
     console.log('The file saved to ', res.path())
     // Beware that when using a file path as Image source on Android,
     // you must prepend "file://"" before the file path
-    imageView = <Image source={{ uri : Platform.OS === 'android' ? 'file://' + res.path()  : '' + res.path() }}/>
+    imageView = <Image source={{ uri : Platform.OS === 'android' ? 'file://' + res.path() : '' + res.path() }}/>
   })
 ```
 

--- a/android.js
+++ b/android.js
@@ -38,9 +38,25 @@ function addCompleteDownload(config) {
     return Promise.reject('RNFetchBlob.android.addCompleteDownload only supports Android.')
 }
 
+function getSDCardDir() {
+  if(Platform.OS === 'android')
+    return RNFetchBlob.getSDCardDir()
+  else
+    return Promise.reject('RNFetchBlob.android.getSDCardDir only supports Android.')
+}
+
+function getSDCardApplicationDir() {
+  if(Platform.OS === 'android')
+    return RNFetchBlob.getSDCardApplicationDir()
+  else
+    return Promise.reject('RNFetchBlob.android.getSDCardApplicationDir only supports Android.')
+}
+
 
 export default {
   actionViewIntent,
   getContentIntent,
-  addCompleteDownload
+  addCompleteDownload,
+  getSDCardDir,
+  getSDCardApplicationDir,
 }

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -92,7 +92,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 RNFetchBlobFS.createFile(path, content, encode, callback);
             }
         });
-
     }
 
     @ReactMethod
@@ -136,7 +135,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 RNFetchBlobFS.createFileASCII(path, dataArray, callback);
             }
         });
-
     }
 
     @ReactMethod
@@ -167,7 +165,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 RNFetchBlobFS.cp(path, dest, callback);
             }
         });
-
     }
 
     @ReactMethod
@@ -228,7 +225,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 RNFetchBlobFS.writeFile(path, encoding, data, append, promise);
             }
         });
-
     }
 
     @ReactMethod
@@ -263,7 +259,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 new RNFetchBlobFS(ctx).scanFile(p, m, callback);
             }
         });
-
     }
 
     @ReactMethod
@@ -324,7 +319,7 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     @ReactMethod
     public void fetchBlob(ReadableMap options, String taskId, String method, String url, ReadableMap headers, String body, final Callback callback) {
         new RNFetchBlobReq(options, taskId, method, url, headers, body, null, mClient, callback).run();
-}
+    }
 
     @ReactMethod
     public void fetchBlobForm(ReadableMap options, String taskId, String method, String url, ReadableMap headers, ReadableArray body, final Callback callback) {
@@ -370,4 +365,13 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
 
     }
 
+    @ReactMethod
+    public void getSDCardDir(Promise promise) {
+        RNFetchBlobFS.getSDCardDir(promise);
+    }
+
+    @ReactMethod
+    public void getSDCardApplicationDir(Promise promise) {
+        RNFetchBlobFS.getSDCardApplicationDir(this.getReactApplicationContext(), promise);
+    }
 }

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -85,11 +85,11 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void createFile(final String path, final String content, final String encode, final Callback callback) {
+    public void createFile(final String path, final String content, final String encode, final Promise promise) {
         threadPool.execute(new Runnable() {
             @Override
             public void run() {
-                RNFetchBlobFS.createFile(path, content, encode, callback);
+                RNFetchBlobFS.createFile(path, content, encode, promise);
             }
         });
     }
@@ -128,11 +128,11 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void createFileASCII(final String path, final ReadableArray dataArray, final Callback callback) {
+    public void createFileASCII(final String path, final ReadableArray dataArray, final Promise promise) {
         threadPool.execute(new Runnable() {
             @Override
             public void run() {
-                RNFetchBlobFS.createFileASCII(path, dataArray, callback);
+                RNFetchBlobFS.createFileASCII(path, dataArray, promise);
             }
         });
     }

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -727,7 +727,7 @@ public class RNFetchBlobFS {
      * @param encoding Encoding of initial data.
      * @param callback RCT bridge callback.
      */
-    static void createFile(String path, String data, String encoding, Callback callback) {
+    static void createFile(String path, String data, String encoding, Promise promise) {
         try {
             File dest = new File(path);
             boolean created = dest.createNewFile();
@@ -735,7 +735,7 @@ public class RNFetchBlobFS {
                 String orgPath = data.replace(RNFetchBlobConst.FILE_PREFIX, "");
                 File src = new File(orgPath);
                 if(!src.exists()) {
-                    callback.invoke("RNfetchBlob writeFileError", "source file : " + data + "not exists");
+                    promise.reject("RNfetchBlob writeFileError", "source file : " + data + "not exists");
                     return ;
                 }
                 FileInputStream fin = new FileInputStream(src);
@@ -751,15 +751,15 @@ public class RNFetchBlobFS {
             }
             else {
                 if (!created) {
-                    callback.invoke("create file error: failed to create file at path `" + path + "` for its parent path may not exists, or the file already exists. If you intended to overwrite the existing file use fs.writeFile instead.");
+                    Promise.reject("create file error: failed to create file at path `" + path + "` for its parent path may not exists, or the file already exists. If you intended to overwrite the existing file use fs.writeFile instead.");
                     return;
                 }
                 OutputStream ostream = new FileOutputStream(dest);
                 ostream.write(RNFetchBlobFS.stringToBytes(data, encoding));
             }
-            callback.invoke(null, path);
+            promise.resolve(path);
         } catch(Exception err) {
-            callback.invoke(err.getLocalizedMessage());
+            promise.reject(err.getLocalizedMessage());
         }
     }
 
@@ -769,16 +769,16 @@ public class RNFetchBlobFS {
      * @param data  Content of new file
      * @param callback  JS context callback
      */
-    static void createFileASCII(String path, ReadableArray data, Callback callback) {
+    static void createFileASCII(String path, ReadableArray data, Promise promise) {
         try {
             File dest = new File(path);
             if(dest.exists()) {
-                callback.invoke("create file error: failed to create file at path `" + path + "`, file already exists.");
+                promise.reject("create file error: failed to create file at path `" + path + "`, file already exists.");
                 return;
             }
             boolean created = dest.createNewFile();
             if(!created) {
-                callback.invoke("create file error: failed to create file at path `" + path + "` for its parent path may not exists");
+                promise.reject("create file error: failed to create file at path `" + path + "` for its parent path may not exists");
                 return;
             }
             OutputStream ostream = new FileOutputStream(dest);
@@ -788,9 +788,9 @@ public class RNFetchBlobFS {
             }
             ostream.write(chunk);
             chunk = null;
-            callback.invoke(null, path);
+            promise.resolve(path);
         } catch(Exception err) {
-            callback.invoke(err.getLocalizedMessage());
+            promise.reject(err.getLocalizedMessage());
         }
     }
 

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -213,10 +213,36 @@ public class RNFetchBlobFS {
         state = Environment.getExternalStorageState();
         if (state.equals(Environment.MEDIA_MOUNTED)) {
             res.put("SDCardDir", Environment.getExternalStorageDirectory().getAbsolutePath());
-            res.put("SDCardApplicationDir", ctx.getExternalFilesDir(null).getParentFile().getAbsolutePath());
+            try {
+                res.put("SDCardApplicationDir", ctx.getExternalFilesDir(null).getParentFile().getAbsolutePath());
+            } catch(Exception e) {
+                res.put("SDCardApplicationDir", "");
+            }
         }
         res.put("MainBundleDir", ctx.getApplicationInfo().dataDir);
         return res;
+    }
+
+    static public void getSDCardDir(Promise promise) {
+        if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
+            promise.resolve(Environment.getExternalStorageDirectory().getAbsolutePath());
+        } else {
+            promise.reject("RNFetchBlob.getSDCardDir", "External storage not mounted");
+        }
+
+    }
+
+    static public void getSDCardApplicationDir(ReactApplicationContext ctx, Promise promise) {
+        if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
+            try {
+                final String path = ctx.getExternalFilesDir(null).getParentFile().getAbsolutePath();
+                promise.resolve(path);
+            } catch (Exception e) {
+                promise.reject("RNFetchBlob.getSDCardApplicationDir", e.getLocalizedMessage());
+            }
+        } else {
+            promise.reject("RNFetchBlob.getSDCardApplicationDir", "External storage not mounted");
+        }
     }
 
     /**

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -150,6 +150,14 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 }
                 // set headers
                 ReadableMapKeySetIterator it = headers.keySetIterator();
+                // #391 Add MIME type to the request
+                if(options.addAndroidDownloads.hasKey("mime")) {
+                    req.setMimeType(options.addAndroidDownloads.getString("mime"));
+                }
+
+                if(options.addAndroidDownloads.hasKey("mediaScannable") && options.addAndroidDownloads.hasKey("mediaScannable") == true ) {
+                    req.allowScanningByMediaScanner();
+                }
                 while (it.hasNextKey()) {
                     String key = it.nextKey();
                     req.addRequestHeader(key, headers.getString(key));
@@ -636,16 +644,20 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                         return;
                     }
                     String contentUri = c.getString(c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI));
-                    if (contentUri != null) {
+                    if ( contentUri != null &&
+                            options.addAndroidDownloads.hasKey("mime") &&
+                            options.addAndroidDownloads.getString("mime").contains("image")) {
                         Uri uri = Uri.parse(contentUri);
                         Cursor cursor = appCtx.getContentResolver().query(uri, new String[]{android.provider.MediaStore.Images.ImageColumns.DATA}, null, null, null);
-                        // use default destination of DownloadManager
+
+                            // use default destination of DownloadManager
                         if (cursor != null) {
                             cursor.moveToFirst();
                             filePath = cursor.getString(0);
                         }
                     }
                 }
+
                 // When the file is not found in media content database, check if custom path exists
                 if (options.addAndroidDownloads.hasKey("path")) {
                     try {

--- a/fs.js
+++ b/fs.js
@@ -28,8 +28,17 @@ const dirs = {
     MovieDir : RNFetchBlob.MovieDir,
     DownloadDir : RNFetchBlob.DownloadDir,
     DCIMDir : RNFetchBlob.DCIMDir,
-    SDCardDir : RNFetchBlob.SDCardDir,
-    SDCardApplicationDir : RNFetchBlob.SDCardApplicationDir,
+    get SDCardDir() {
+      console.warn('SDCardDir as a constant is deprecated and will be removed in feature release. ' +
+                   'Use RNFetchBlob.android.getSDCardDir():Promise instead.');
+      return RNFetchBlob.SDCardDir;
+    },
+    get SDCardApplicationDir() {
+      console.warn('SDCardApplicationDir as a constant is deprecated and will be removed in feature release. ' +
+                   'Use RNFetchBlob.android.getSDCardApplicationDir():Promise instead. ' +
+                   'This variable can be empty on error in native code.');
+      return RNFetchBlob.SDCardApplicationDir;
+    },
     MainBundleDir : RNFetchBlob.MainBundleDir,
     LibraryDir : RNFetchBlob.LibraryDir
 }

--- a/ios.js
+++ b/ios.js
@@ -43,7 +43,7 @@ function openDocument(path:string, scheme:string) {
  * @param  {string} url URL of the resource, only file URL is supported
  * @return {Promise}
  */
-function excludeFromBackupKey(url:string) {
+function excludeFromBackupKey(path:string) {
   return RNFetchBlob.excludeFromBackupKey('file://' + path);
 }
 

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -106,8 +106,12 @@ NSOperationQueue *taskQueue;
 - (id)init {
     self = [super init];
     if(taskQueue == nil) {
-        taskQueue = [[NSOperationQueue alloc] init];
-        taskQueue.maxConcurrentOperationCount = 10;
+        @synchronized ([RNFetchBlobNetwork class]) {
+            if (taskQueue == nil) {
+                taskQueue = [[NSOperationQueue alloc] init];
+                taskQueue.maxConcurrentOperationCount = 10;
+            }
+        }
     }
     return self;
 }

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -105,12 +105,10 @@ NSOperationQueue *taskQueue;
 // constructor
 - (id)init {
     self = [super init];
-    if(taskQueue == nil) {
-        @synchronized ([RNFetchBlobNetwork class]) {
-            if (taskQueue == nil) {
-                taskQueue = [[NSOperationQueue alloc] init];
-                taskQueue.maxConcurrentOperationCount = 10;
-            }
+    @synchronized ([RNFetchBlobNetwork class]) {
+        if (taskQueue == nil) {
+            taskQueue = [[NSOperationQueue alloc] init];
+            taskQueue.maxConcurrentOperationCount = 10;
         }
     }
     return self;
@@ -118,20 +116,24 @@ NSOperationQueue *taskQueue;
 
 + (void) enableProgressReport:(NSString *) taskId config:(RNFetchBlobProgress *)config
 {
-    if(progressTable == nil)
-    {
-        progressTable = [[NSMutableDictionary alloc] init];
+    @synchronized ([RNFetchBlobNetwork class]) {
+        if(progressTable == nil)
+        {
+            progressTable = [[NSMutableDictionary alloc] init];
+        }
+        [progressTable setValue:config forKey:taskId];
     }
-    [progressTable setValue:config forKey:taskId];
 }
 
 + (void) enableUploadProgress:(NSString *) taskId config:(RNFetchBlobProgress *)config
 {
-    if(uploadProgressTable == nil)
-    {
-        uploadProgressTable = [[NSMutableDictionary alloc] init];
+    @synchronized ([RNFetchBlobNetwork class]) {
+        if(uploadProgressTable == nil)
+        {
+            uploadProgressTable = [[NSMutableDictionary alloc] init];
+        }
+        [uploadProgressTable setValue:config forKey:taskId];
     }
-    [uploadProgressTable setValue:config forKey:taskId];
 }
 
 // removing case from headers
@@ -245,8 +247,10 @@ NSOperationQueue *taskQueue;
     }
 
     __block NSURLSessionDataTask * task = [session dataTaskWithRequest:req];
-    [taskTable setObject:task forKey:taskId];
-    [task resume];
+    @synchronized ([RNFetchBlobNetwork class]){
+        [taskTable setObject:task forKey:taskId];
+        [task resume];
+    }
 
     // network status indicator
     if([[options objectForKey:CONFIG_INDICATOR] boolValue] == YES)
@@ -258,21 +262,22 @@ NSOperationQueue *taskQueue;
 // #115 Invoke fetch.expire event on those expired requests so that the expired event can be handled
 + (void) emitExpiredTasks
 {
-    NSEnumerator * emu =  [expirationTable keyEnumerator];
-    NSString * key;
+    @synchronized ([RNFetchBlobNetwork class]){
+        NSEnumerator * emu =  [expirationTable keyEnumerator];
+        NSString * key;
 
-    while((key = [emu nextObject]))
-    {
-        RCTBridge * bridge = [RNFetchBlob getRCTBridge];
-        NSData * args = @{ @"taskId": key };
-        [bridge.eventDispatcher sendDeviceEventWithName:EVENT_EXPIRE body:args];
+        while((key = [emu nextObject]))
+        {
+            RCTBridge * bridge = [RNFetchBlob getRCTBridge];
+            NSData * args = @{ @"taskId": key };
+            [bridge.eventDispatcher sendDeviceEventWithName:EVENT_EXPIRE body:args];
 
+        }
+
+        // clear expired task entries
+        [expirationTable removeAllObjects];
+        expirationTable = [[NSMapTable alloc] init];
     }
-
-    // clear expired task entries
-    [expirationTable removeAllObjects];
-    expirationTable = [[NSMapTable alloc] init];
-
 }
 
 ////////////////////////////////////////
@@ -452,10 +457,18 @@ NSOperationQueue *taskQueue;
     {
         [writeStream write:[data bytes] maxLength:[data length]];
     }
-    RNFetchBlobProgress * pconfig = [progressTable valueForKey:taskId];
+    
     if(expectedBytes == 0)
         return;
+    
+    RNFetchBlobProgress * pconfig;
+    
+    @synchronized ([RNFetchBlobNetwork class]){
+        pconfig = [progressTable valueForKey:taskId];
+    }
+        
     NSNumber * now =[NSNumber numberWithFloat:((float)receivedBytes/(float)expectedBytes)];
+    
     if(pconfig != nil && [pconfig shouldReport:now])
     {
         [self.bridge.eventDispatcher
@@ -465,11 +478,9 @@ NSOperationQueue *taskQueue;
                 @"written": [NSString stringWithFormat:@"%d", receivedBytes],
                 @"total": [NSString stringWithFormat:@"%d", expectedBytes],
                 @"chunk": chunkString
-            }
+                }
          ];
     }
-    received = nil;
-
 }
 
 - (void) URLSession:(NSURLSession *)session didBecomeInvalidWithError:(nullable NSError *)error
@@ -541,7 +552,7 @@ NSOperationQueue *taskQueue;
 
     callback(@[ errMsg, rnfbRespType, respStr]);
 
-    @synchronized(taskTable, uploadProgressTable, progressTable)
+    @synchronized ([RNFetchBlobNetwork class])
     {
         if([taskTable objectForKey:taskId] == nil)
             NSLog(@"object released by ARC.");
@@ -560,17 +571,23 @@ NSOperationQueue *taskQueue;
 // upload progress handler
 - (void) URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesWritten totalBytesExpectedToSend:(int64_t)totalBytesExpectedToWrite
 {
-    RNFetchBlobProgress * pconfig = [uploadProgressTable valueForKey:taskId];
     if(totalBytesExpectedToWrite == 0)
         return;
+    
+    RNFetchBlobProgress * pconfig;
+    
+    @synchronized ([RNFetchBlobNetwork class]) {
+        pconfig = [uploadProgressTable valueForKey:taskId];
+    }
+    
     NSNumber * now = [NSNumber numberWithFloat:((float)totalBytesWritten/(float)totalBytesExpectedToWrite)];
     if(pconfig != nil && [pconfig shouldReport:now]) {
         [self.bridge.eventDispatcher
          sendDeviceEventWithName:EVENT_PROGRESS_UPLOAD
          body:@{
                 @"taskId": taskId,
-                @"written": [NSString stringWithFormat:@"%d", totalBytesWritten],
-                @"total": [NSString stringWithFormat:@"%d", totalBytesExpectedToWrite]
+                @"written": [NSString stringWithFormat:@"%ld", (long) totalBytesWritten],
+                @"total": [NSString stringWithFormat:@"%ld", (long) totalBytesExpectedToWrite]
                 }
          ];
     }
@@ -578,7 +595,12 @@ NSOperationQueue *taskQueue;
 
 + (void) cancelRequest:(NSString *)taskId
 {
-    NSURLSessionDataTask * task = [taskTable objectForKey:taskId];
+    NSURLSessionDataTask * task;
+    
+    @synchronized ([RNFetchBlobNetwork class]) {
+        task = [taskTable objectForKey:taskId];
+    }
+    
     if(task != nil && task.state == NSURLSessionTaskStateRunning)
         [task cancel];
 }

--- a/ios/RNFetchBlobRequest.m
+++ b/ios/RNFetchBlobRequest.m
@@ -374,7 +374,11 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
     });
     
     if (error) {
-        errMsg = [error localizedDescription];
+        if (error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled) {
+            errMsg = @"task cancelled";
+        } else {
+            errMsg = [error localizedDescription];
+        }
     }
     
     if (respFile) {

--- a/ios/RNFetchBlobRequest.m
+++ b/ios/RNFetchBlobRequest.m
@@ -162,7 +162,9 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
     
     // network status indicator
     if ([[options objectForKey:CONFIG_INDICATOR] boolValue]) {
-        [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+        });
     }
 }
 
@@ -367,7 +369,9 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
     NSString * respStr;
     NSString * rnfbRespType;
     
-    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+    });
     
     if (error) {
         errMsg = [error localizedDescription];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fetch-blob",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fetch-blob",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "base-64": "0.1.0",
-    "glob": "^7.0.6"
+    "glob": "7.0.6"
   },
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fetch-blob",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {

--- a/polyfill/Blob.js
+++ b/polyfill/Blob.js
@@ -286,7 +286,7 @@ export default class Blob extends EventTarget {
 
   safeClose() {
     if(this._closed)
-      return Promise.reject('Blob has been released.)
+      return Promise.reject('Blob has been released.')
     this._closed = true
     if(!this._isReference) {
       return fs.unlink(this._ref).catch((err) => {

--- a/polyfill/XMLHttpRequest.js
+++ b/polyfill/XMLHttpRequest.js
@@ -277,7 +277,7 @@ export default class XMLHttpRequest extends XMLHttpRequestEventTarget{
   _headerReceived = (e) => {
     log.debug('header received ', this._task.taskId, e)
     this.responseURL = this._url
-    if(e.state === "2") {
+    if(e.state === "2" && e.taskId === this._task.taskId) {
       this._responseHeaders = e.headers
       this._statusText = e.status
       this._status = Math.floor(e.status)

--- a/react-native-fetch-blob.podspec
+++ b/react-native-fetch-blob.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name             = "react-native-fetch-blob"
-  s.version          = "0.10.3-beta.1"
+  s.version          = "0.10.6"
   s.summary          = "A project committed to make file acess and data transfer easier, effiecient for React Native developers."
   s.requires_arc = true
   s.license      = 'MIT'
   s.homepage     = 'n/a'
   s.authors      = { "wkh237" => "xeiyan@gmail.com" }
-  s.source       = { :git => "https://github.com/wkh237/react-native-fetch-blob", :tag => 'v0.10.3-beta.1'}
+  s.source       = { :git => "https://github.com/wkh237/react-native-fetch-blob", :tag => 'v0.10.6'}
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "7.0"
   s.dependency 'React/Core'


### PR DESCRIPTION
COPY OF: https://github.com/wkh237/react-native-fetch-blob/pull/636

Hi,

this PR came from crashes we still get (some description):
https://github.com/wcandillon/react-native-img-cache/issues/95

...but evolved.

Whole RNFetchBlobNetwork class actually do two things:
- keeping tasks references to cancel them, change their progress config etc.,
- session and requests logic.

I moved session and requests logic into separate file, now it's more clean what do what.
```NSMapTable``` seemed to be used incorrectly or just it's (weak) features not used (it seems from log ```NSLog(@"object released by ARC.");``` that it should or was used), anyway, it's now instantiated with ```NSMapTableWeakMemory``` option for objects, so requests will be released, default in NSMapTable is to use strong references.

```sharedInstance``` is used instead tables and dictionaries instances created on load. This pattern is used all around but please give me a feedback why previous is better solution, maybe I missed something.

Other things done in this PR when implementing:
- ```checkExpiredSessions``` didn’t find anywhere, removed from header
- __block storage type not needed, variables not used in blocks in scope
- extern storage type not used in .m files
- nullability type in RNFetchBlobNetwork, should be checked and applied for method arguments in other classes
- unimplemented ```+ (void) enableProgressReport:(NSString *) taskId, + (void) enableUploadProgress:(NSString *) taskId, - (void) sendRequest``` method declarations removed
unused ```fileTaskCompletionHandler``` and ```dataTaskCompletionHandler``` properties and synthesizers removed
- other small warning messages fixes
- every single request is created on new RNFetchBlobNetwork instance so taskQueue.maxConcurrentOperationCount seems not work as expected -> made taskQueue instantiated per RNFetchBlobNetwork instance.

I can't find any place where actually something is added to ```expirationTable```.

Does ```HTTPMaximumConnectionsPerHost = 10``` have any impact as new session is created for every request (except ```defaultSessionConfiguration```)? In docs it says that it applies to all sessions ```'...based on this configuration'```, what actually this means, the same instance, identifier or some comparison???

I'm aware of few fixes that are in 0.10.9 not included here.

TODO:
- subclass RCTEventEmitter to send events
- expired task logic?

This works for now for us, but didn't test everything and any feedback or testing would be great.


POST 16.01.2018

What about applying:
http://google.github.io/styleguide/objcguide.html
I agree with that code guideline mostly.


POST 19.01.2018:

https://github.com/flatfox-ag/react-native-fetch-blob/tree/exception_fixes 2 days already in production, no exceptions yet.

This branch have all these fixes:
https://github.com/wkh237/react-native-fetch-blob/pull/619
https://github.com/wkh237/react-native-fetch-blob/pull/499

and all changes from:
https://github.com/flatfox-ag/react-native-fetch-blob/tree/synchronized

feel free to:
```"react-native-fetch-blob": "github:flatfox-ag/react-native-fetch-blob#a46bf8180d76131eafe84ab44e0436322073820c",```

As we use it in production I removed WIP note.
Stuff in TODO will come in different PRs I guess.

POST 25.01.2018

Week without crashes on production, fixes confirmed :)
