### PR TITLE
Implement `requiresMainQueueSetup`, fixes #553

### DIFF
--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -70,6 +70,11 @@ RCT_EXPORT_MODULE();
              };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 // Fetch blob data request
 RCT_EXPORT_METHOD(fetchBlobForm:(NSDictionary *)options
                   taskId:(NSString *)taskId


### PR DESCRIPTION
Previous PR https://github.com/wkh237/react-native-fetch-blob/pull/674 closed due to new maintainers and repository location.
See https://github.com/wkh237/react-native-fetch-blob/issues/553 for details about the issue being resolved.