### PR TITLE
Reject promise by iOS openDocument when a file is not opened

### DIFF
--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -588,9 +588,12 @@ RCT_EXPORT_METHOD(openDocument:(NSString*)uri scheme:(NSString *)scheme resolver
 
     if(scheme == nil || [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:scheme]]) {
         dispatch_sync(dispatch_get_main_queue(), ^{
-            [documentController presentPreviewAnimated:YES];
+            if([documentController presentPreviewAnimated:YES]) {
+                resolve(@[[NSNull null]]);
+            } else {
+                reject(@"EINVAL", @"document is not supported", nil);
+            }
         });
-        resolve(@[[NSNull null]]);
     } else {
         reject(@"EINVAL", @"scheme is not supported", nil);
     }


### PR DESCRIPTION
**openDocument** method (iOS) may be unable to open unsupported files. In this case it's better to reject returning promise.