### PR TITLE
Bug fix: Support Android content URIs for upload

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobBody.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobBody.java
@@ -68,7 +68,7 @@ class RNFetchBlobBody extends RequestBody{
         try {
             switch (requestType) {
                 case SingleFile:
-                    requestStream = getReuqestStream();
+                    requestStream = getRequestStream();
                     contentLength = requestStream.available();
                     break;
                 case AsIs:
@@ -135,7 +135,7 @@ class RNFetchBlobBody extends RequestBody{
         return true;
     }
 
-    private InputStream getReuqestStream() throws Exception {
+    private InputStream getRequestStream() throws Exception {
 
         // upload from storage
         if (rawBody.startsWith(RNFetchBlobConst.FILE_PREFIX)) {

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobBody.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobBody.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 
+import android.net.Uri;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import okio.BufferedSink;
@@ -159,6 +160,13 @@ class RNFetchBlobBody extends RequestBody{
                     throw new Exception("error when getting request stream: " +e.getLocalizedMessage());
                 }
             }
+        } else if (rawBody.startsWith(RNFetchBlobConst.CONTENT_PREFIX)) {
+            String contentURI = rawBody.substring(RNFetchBlobConst.CONTENT_PREFIX.length());
+            try {
+                return RNFetchBlob.RCTContext.getContentResolver().openInputStream(Uri.parse(contentURI));
+            } catch (Exception e) {
+                throw new Exception("error when getting request stream for content URI: " + contentURI, e);
+            }
         }
         // base 64 encoded
         else {
@@ -222,6 +230,20 @@ class RNFetchBlobBody extends RequestBody{
                         }
                         else {
                             RNFetchBlobUtils.emitWarningEvent("Failed to create form data from path :" + orgPath + ", file not exists.");
+                        }
+                    }
+                } else if (data.startsWith(RNFetchBlobConst.CONTENT_PREFIX)) {
+                    String contentURI = data.substring(RNFetchBlobConst.CONTENT_PREFIX.length());
+                    InputStream is = null;
+                    try {
+                        is = ctx.getContentResolver().openInputStream(Uri.parse(contentURI));
+                        pipeStreamToFileStream(is, os);
+                    } catch(Exception e) {
+                        RNFetchBlobUtils.emitWarningEvent(
+                                "Failed to create form data from content URI:" + contentURI + ", " + e.getLocalizedMessage());
+                    } finally {
+                        if (is != null) {
+                            is.close();
                         }
                     }
                 }
@@ -289,7 +311,7 @@ class RNFetchBlobBody extends RequestBody{
      * Compute approximate content length for form data
      * @return ArrayList<FormField>
      */
-    private ArrayList<FormField> countFormDataLength() {
+    private ArrayList<FormField> countFormDataLength() throws IOException {
         long total = 0;
         ArrayList<FormField> list = new ArrayList<>();
         ReactApplicationContext ctx = RNFetchBlob.RCTContext;
@@ -319,6 +341,21 @@ class RNFetchBlobBody extends RequestBody{
                     else {
                         File file = new File(RNFetchBlobFS.normalizePath(orgPath));
                         total += file.length();
+                    }
+                } else if (data.startsWith(RNFetchBlobConst.CONTENT_PREFIX)) {
+                    String contentURI = data.substring(RNFetchBlobConst.CONTENT_PREFIX.length());
+                    InputStream is = null;
+                    try {
+                        is = ctx.getContentResolver().openInputStream(Uri.parse(contentURI));
+                        long length = is.available();
+                        total += length;
+                    } catch(Exception e) {
+                        RNFetchBlobUtils.emitWarningEvent(
+                                "Failed to estimate form data length from content URI:" + contentURI + ", " + e.getLocalizedMessage());
+                    } finally {
+                        if (is != null) {
+                            is.close();
+                        }
                     }
                 }
                 // base64 embedded file content

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobConst.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobConst.java
@@ -7,6 +7,7 @@ public class RNFetchBlobConst {
     public static final String EVENT_HTTP_STATE = "RNFetchBlobState";
     public static final String EVENT_MESSAGE = "RNFetchBlobMessage";
     public static final String FILE_PREFIX = "RNFetchBlob-file://";
+    public static final String CONTENT_PREFIX = "RNFetchBlob-content://";
     public static final String FILE_PREFIX_BUNDLE_ASSET = "bundle-assets://";
     public static final String FILE_PREFIX_CONTENT = "content://";
     public static final String DATA_ENCODE_URI = "uri";

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -266,7 +266,8 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                     requestType = RequestType.SingleFile;
                 }
                 if(rawRequestBody != null) {
-                    if(rawRequestBody.startsWith(RNFetchBlobConst.FILE_PREFIX)) {
+                    if (rawRequestBody.startsWith(RNFetchBlobConst.FILE_PREFIX)
+                            || rawRequestBody.startsWith(RNFetchBlobConst.CONTENT_PREFIX)) {
                         requestType = RequestType.SingleFile;
                     }
                     else if (cType.toLowerCase().contains(";base64") || cType.toLowerCase().startsWith("application/octet")) {

--- a/index.js
+++ b/index.js
@@ -79,7 +79,8 @@ if(!RNFetchBlob || !RNFetchBlob.fetchBlobForm || !RNFetchBlob.fetchBlob) {
 }
 
 function wrap(path:string):string {
-  return 'RNFetchBlob-file://' + path
+  const prefix = path.startsWith('content://') ? 'RNFetchBlob-content://' : 'RNFetchBlob-file://'
+  return prefix + path
 }
 
 /**


### PR DESCRIPTION
This is basically the same PR as https://github.com/joltup/react-native-fetch-blob/pull/3 opened by @tombailey (thanks!) but against the 0.10.9 branch like it was asked in https://github.com/joltup/react-native-fetch-blob/pull/3#issuecomment-381353329 since this is a bug fix.

It needs review and testing but it would be nice to have it merged in a near future since the current release 0.10.8 doesn't handle Android content URIs properly, which prevents from using `react-native-fetch-blob` to upload blobs represented by such content URIs.

For instance, the content URIs returned by `intent.getParcelableExtra(Intent.EXTRA_STREAM)` when sending an intent to our app can look like:

Google Photos:
`content://com.google.android.apps.photos.contentprovider/0/1/content%3A%2F%2Fmedia%2Fexternal%2Fimages%2Fmedia%2F31833/REQUIRE_ORIGINAL/NONE/209919194`

Downloads:
`content://com.android.providers.downloads.documents/document/3814`

Google Drive:
`content://com.google.android.apps.docs.storage.legacy/enc%3DmGl-r0bYICO3TK1M5bk1Tso5F5mKyWsFOBnm8_jU1yMvYtpA%0A`

Calling `RNFetchBlob.fetch('POST', url, headers, RNFetchBlob.wrap(contentURI))` with such content URIs might fail with:
```
05-15 17:41:14.050 26128 28065 W System.err: java.lang.NullPointerException: Attempt to invoke virtual method 'char[] java.lang.String.toCharArray()' on a null object reference
05-15 17:41:14.051 26128 28065 W System.err: 	at java.io.File.fixSlashes(File.java:183)
05-15 17:41:14.051 26128 28065 W System.err: 	at java.io.File.<init>(File.java:130)
05-15 17:41:14.051 26128 28065 W System.err: 	at com.RNFetchBlob.RNFetchBlobBody.getReuqestStream(RNFetchBlobBody.java:153)
05-15 17:41:14.051 26128 28065 W System.err: 	at com.RNFetchBlob.RNFetchBlobBody.setBody(RNFetchBlobBody.java:71)
05-15 17:41:14.052 26128 28065 W System.err: 	at com.RNFetchBlob.RNFetchBlobReq.run(RNFetchBlobReq.java:280)
05-15 17:41:14.052 26128 28065 W System.err: 	at com.RNFetchBlob.RNFetchBlob.fetchBlob(RNFetchBlob.java:326)
05-15 17:41:14.052 26128 28065 W System.err: 	at java.lang.reflect.Method.invoke(Native Method)
05-15 17:41:14.052 26128 28065 W System.err: 	at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
05-15 17:41:14.052 26128 28065 W System.err: 	at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:160)
05-15 17:41:14.052 26128 28065 W System.err: 	at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
05-15 17:41:14.052 26128 28065 W System.err: 	at android.os.Handler.handleCallback(Handler.java:739)
05-15 17:41:14.052 26128 28065 W System.err: 	at android.os.Handler.dispatchMessage(Handler.java:95)
05-15 17:41:14.052 26128 28065 W System.err: 	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)
05-15 17:41:14.052 26128 28065 W System.err: 	at android.os.Looper.loop(Looper.java:148)
05-15 17:41:14.052 26128 28065 W System.err: 	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:192)
05-15 17:41:14.052 26128 28065 W System.err: 	at java.lang.Thread.run(Thread.java:818)
05-15 17:41:14.040  1049  1049 W Binder_5: type=1400 audit(0.0:38422): avc: denied { ioctl } for path="socket:[3983576]" dev="sockfs" ino=3983576 ioctlcmd=7704 scontext=u:r:system_server:s0 tcontext=u:r:system_server:s0 tclass=unix_stream_socket permissive=0
05-15 17:41:14.040  1049  1049 W Binder_5: type=1400 audit(0.0:38423): avc: denied { ioctl } for path="socket:[3983576]" dev="sockfs" ino=3983576 ioctlcmd=7704 scontext=u:r:system_server:s0 tcontext=u:r:system_server:s0 tclass=unix_stream_socket permissive=0
05-15 17:41:14.063 26128 28064 W ReactNativeJS: RNFetchBlob failed to create single content request body :Attempt to invoke virtual method 'char[] java.lang.String.toCharArray()' on a null object reference
05-15 17:41:14.075 26128 28064 W ReactNativeJS: Attempt to invoke virtual method 'int java.io.InputStream.read(byte[], int, int)' on a null object reference
05-15 17:41:14.075 26128 26940 W System.err: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.io.InputStream.read(byte[], int, int)' on a null object reference
05-15 17:41:14.076 26128 26940 W System.err: 	at com.RNFetchBlob.RNFetchBlobBody.pipeStreamToSink(RNFetchBlobBody.java:266)
05-15 17:41:14.076 26128 26940 W System.err: 	at com.RNFetchBlob.RNFetchBlobBody.writeTo(RNFetchBlobBody.java:119)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.java:59)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
05-15 17:41:14.076 26128 26940 W System.err: 	at com.RNFetchBlob.RNFetchBlobReq$1.intercept(RNFetchBlobReq.java:318)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:45)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:93)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:120)
05-15 17:41:14.076 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
05-15 17:41:14.077 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
05-15 17:41:14.077 26128 26940 W System.err: 	at com.RNFetchBlob.RNFetchBlobReq$2.intercept(RNFetchBlobReq.java:326)
05-15 17:41:14.077 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:92)
05-15 17:41:14.078 26128 26940 W System.err: 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:67)
05-15 17:41:14.078 26128 26940 W System.err: 	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:179)
05-15 17:41:14.078 26128 26940 W System.err: 	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:129)
05-15 17:41:14.078 26128 26940 W System.err: 	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
05-15 17:41:14.078 26128 26940 W System.err: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
05-15 17:41:14.078 26128 26940 W System.err: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
05-15 17:41:14.078 26128 26940 W System.err: 	at java.lang.Thread.run(Thread.java:818)
```

Thanks!