### PR TITLE
Bug Fix Branch 0.10.9 "...exposed beyond app through Intent.getData() " at Android N 

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Aug 12 07:48:35 CEST 2017
+#Fri Jun 01 10:33:07 BRT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,9 +1,37 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.RNFetchBlob">
 
-    <application
-        android:label="@string/app_name">
+    <!-- Required to access Google Play Licensing -->
+    <uses-permission android:name="com.android.vending.CHECK_LICENSE" />
 
+    <!-- Required to download files from Google Play -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- Required to keep CPU alive while downloading files
+        (NOT to keep screen awake) -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <!-- Required to poll the state of the network connection
+        and respond to changes -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <!-- Required to check whether Wi-Fi is enabled -->
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+
+    <!-- Required to read and write the expansion files on shared storage -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+    <application android:label="@string/app_name">
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -7,7 +7,6 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
 import android.support.v4.content.FileProvider;
-import android.util.SparseArray;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Callback;
@@ -24,8 +23,6 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.network.ForwardingCookieHandler;
 import com.facebook.react.modules.network.CookieJarContainer;
 import com.facebook.react.modules.network.OkHttpClientProvider;
-import com.squareup.okhttp.OkHttpClient;
-
 import okhttp3.OkHttpClient;
 import okhttp3.JavaNetCookieJar;
 
@@ -41,23 +38,26 @@ import static com.RNFetchBlob.RNFetchBlobConst.GET_CONTENT_INTENT;
 
 public class RNFetchBlob extends ReactContextBaseJavaModule {
 
+    // Cookies
+    private final ForwardingCookieHandler mCookieHandler;
+    private final CookieJarContainer mCookieJarContainer;
     private final OkHttpClient mClient;
 
     static ReactApplicationContext RCTContext;
-    private static LinkedBlockingQueue<Runnable> taskQueue = new LinkedBlockingQueue<>();
-    private static ThreadPoolExecutor threadPool = new ThreadPoolExecutor(5, 10, 5000, TimeUnit.MILLISECONDS, taskQueue);
+    static LinkedBlockingQueue<Runnable> taskQueue = new LinkedBlockingQueue<>();
+    static ThreadPoolExecutor threadPool = new ThreadPoolExecutor(5, 10, 5000, TimeUnit.MILLISECONDS, taskQueue);
     static LinkedBlockingQueue<Runnable> fsTaskQueue = new LinkedBlockingQueue<>();
-    private static ThreadPoolExecutor fsThreadPool = new ThreadPoolExecutor(2, 10, 5000, TimeUnit.MILLISECONDS, taskQueue);
-    private static boolean ActionViewVisible = false;
-    private static SparseArray<Promise> promiseTable = new SparseArray<>();
+    static ThreadPoolExecutor fsThreadPool = new ThreadPoolExecutor(2, 10, 5000, TimeUnit.MILLISECONDS, taskQueue);
+    static public boolean ActionViewVisible = false;
+    static HashMap<Integer, Promise> promiseTable = new HashMap<>();
 
     public RNFetchBlob(ReactApplicationContext reactContext) {
 
         super(reactContext);
 
         mClient = OkHttpClientProvider.getOkHttpClient();
-        ForwardingCookieHandler mCookieHandler = new ForwardingCookieHandler(reactContext);
-        CookieJarContainer mCookieJarContainer = (CookieJarContainer) mClient.cookieJar();
+        mCookieHandler = new ForwardingCookieHandler(reactContext);
+        mCookieJarContainer = (CookieJarContainer) mClient.cookieJar();
         mCookieJarContainer.setCookieJar(new JavaNetCookieJar(mCookieHandler));
 
         RCTContext = reactContext;
@@ -89,23 +89,14 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void createFile(final String path, final String content, final String encode, final Promise promise) {
+    public void createFile(final String path, final String content, final String encode, final Callback callback) {
         threadPool.execute(new Runnable() {
             @Override
             public void run() {
-                RNFetchBlobFS.createFile(path, content, encode, promise);
+                RNFetchBlobFS.createFile(path, content, encode, callback);
             }
         });
-    }
 
-    @ReactMethod
-    public void createFileASCII(final String path, final ReadableArray dataArray, final Promise promise) {
-        threadPool.execute(new Runnable() {
-            @Override
-            public void run() {
-                RNFetchBlobFS.createFileASCII(path, dataArray, promise);
-            }
-        });
     }
 
     @ReactMethod
@@ -156,8 +147,19 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
             };
             RCTContext.addLifecycleEventListener(listener);
         } catch(Exception ex) {
-            promise.reject("EUNSPECIFIED", ex.getLocalizedMessage());
+            promise.reject(ex.getLocalizedMessage());
         }
+    }
+
+    @ReactMethod
+    public void createFileASCII(final String path, final ReadableArray dataArray, final Callback callback) {
+        threadPool.execute(new Runnable() {
+            @Override
+            public void run() {
+                RNFetchBlobFS.createFileASCII(path, dataArray, callback);
+            }
+        });
+
     }
 
     @ReactMethod
@@ -171,8 +173,8 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void mkdir(String path, Promise promise) {
-        RNFetchBlobFS.mkdir(path, promise);
+    public void mkdir(String path, Callback callback) {
+        RNFetchBlobFS.mkdir(path, callback);
     }
 
     @ReactMethod
@@ -188,6 +190,7 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 RNFetchBlobFS.cp(path, dest, callback);
             }
         });
+
     }
 
     @ReactMethod
@@ -196,8 +199,8 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void ls(String path, Promise promise) {
-        RNFetchBlobFS.ls(path, promise);
+    public void ls(String path, Callback callback) {
+        RNFetchBlobFS.ls(path, callback);
     }
 
     @ReactMethod
@@ -248,6 +251,7 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 RNFetchBlobFS.writeFile(path, encoding, data, append, promise);
             }
         });
+
     }
 
     @ReactMethod
@@ -282,24 +286,15 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 new RNFetchBlobFS(ctx).scanFile(p, m, callback);
             }
         });
+
     }
 
     @ReactMethod
-    public void hash(final String path, final String algorithm, final Promise promise) {
-        threadPool.execute(new Runnable() {
-            @Override
-            public void run() {
-                RNFetchBlobFS.hash(path, algorithm, promise);
-            }
-        });
-    }
-
     /**
      * @param path Stream file path
      * @param encoding Stream encoding, should be one of `base64`, `ascii`, and `utf8`
      * @param bufferSize Stream buffer size, default to 4096 or 4095(base64).
      */
-    @ReactMethod
     public void readStream(final String path, final String encoding, final int bufferSize, final int tick, final String streamId) {
         final ReactApplicationContext ctx = this.getReactApplicationContext();
         fsThreadPool.execute(new Runnable() {
@@ -373,10 +368,10 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void addCompleteDownload (ReadableMap config, Promise promise) {
-        DownloadManager dm = (DownloadManager) RCTContext.getSystemService(RCTContext.DOWNLOAD_SERVICE);
+        DownloadManager dm = (DownloadManager) RNFetchBlob.RCTContext.getSystemService(RNFetchBlob.RCTContext.DOWNLOAD_SERVICE);
         String path = RNFetchBlobFS.normalizePath(config.getString("path"));
         if(path == null) {
-            promise.reject("EINVAL", "RNFetchblob.addCompleteDownload can not resolve URI:" + config.getString("path"));
+            promise.reject("RNFetchblob.addCompleteDownload can not resolve URI:" + config.getString("path"), "RNFetchblob.addCompleteDownload can not resolve URI:" + path);
             return;
         }
         try {
@@ -393,18 +388,9 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
             promise.resolve(null);
         }
         catch(Exception ex) {
-            promise.reject("EUNSPECIFIED", ex.getLocalizedMessage());
+            promise.reject("RNFetchblob.addCompleteDownload failed", ex.getStackTrace().toString());
         }
 
     }
 
-    @ReactMethod
-    public void getSDCardDir(Promise promise) {
-        RNFetchBlobFS.getSDCardDir(promise);
-    }
-
-    @ReactMethod
-    public void getSDCardApplicationDir(Promise promise) {
-        RNFetchBlobFS.getSDCardApplicationDir(this.getReactApplicationContext(), promise);
-    }
 }

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -3,7 +3,10 @@ package com.RNFetchBlob;
 import android.app.Activity;
 import android.app.DownloadManager;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
+import android.support.v4.content.FileProvider;
 import android.util.SparseArray;
 
 import com.facebook.react.bridge.ActivityEventListener;
@@ -21,9 +24,12 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.network.ForwardingCookieHandler;
 import com.facebook.react.modules.network.CookieJarContainer;
 import com.facebook.react.modules.network.OkHttpClientProvider;
+import com.squareup.okhttp.OkHttpClient;
+
 import okhttp3.OkHttpClient;
 import okhttp3.JavaNetCookieJar;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -105,10 +111,29 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     @ReactMethod
     public void actionViewIntent(String path, String mime, final Promise promise) {
         try {
-            Intent intent= new Intent(Intent.ACTION_VIEW)
-                    .setDataAndType(Uri.parse("file://" + path), mime);
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            this.getReactApplicationContext().startActivity(intent);
+            Uri uriForFile = FileProvider.getUriForFile(getCurrentActivity(),
+                    this.getReactApplicationContext().getPackageName() + ".provider", new File(path));
+
+            if (Build.VERSION.SDK_INT >= 24) {
+                // Create the intent with data and type
+                Intent intent = new Intent(Intent.ACTION_VIEW)
+                        .setDataAndType(uriForFile, mime);
+
+                // Set flag to give temporary permission to external app to use FileProvider
+                intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+                // Validate that the device can open the file
+                PackageManager pm = getCurrentActivity().getPackageManager();
+                if (intent.resolveActivity(pm) != null) {
+                    this.getReactApplicationContext().startActivity(intent);
+                }
+
+            } else {
+                Intent intent = new Intent(Intent.ACTION_VIEW)
+                        .setDataAndType(Uri.parse("file://" + path), mime).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+                this.getReactApplicationContext().startActivity(intent);
+            }
             ActionViewVisible = true;
 
             final LifecycleEventListener listener = new LifecycleEventListener() {

--- a/android/src/main/res/xml/provider_paths.xml
+++ b/android/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path
+        name="external_files"
+        path="." />
+    <files-path
+        name="files-path"
+        path="." /> <!-- Used to access into application data files -->
+</paths>


### PR DESCRIPTION
This PR is addressed to [#358](https://github.com/wkh237/react-native-fetch-blob/issues/358). It solves the exposed security exception on Android devices with API version >= 24. In older API's the code hasn't changed, still uses file://....