### PR TITLE
No depracation warning on instantiating dirs

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -21,8 +21,8 @@ const dirs = {
   DownloadDir : RNFetchBlob.DownloadDir,
   DCIMDir : RNFetchBlob.DCIMDir,
   SDCardDir: RNFetchBlob.SDCardDir,
-  SDCardApplicationDir: RNFetchBlob.SDCardApplicationDir,
-  MainBundleDir : RNFetchBlob.MainBundleDir,
+  SDCardApplicationDir: RNFetchBlob.SDCardApplicationDir, // Deprecated
+  MainBundleDir : RNFetchBlob.MainBundleDir, // Depracated
   LibraryDir : RNFetchBlob.LibraryDir
 }
 

--- a/fs.js
+++ b/fs.js
@@ -20,17 +20,8 @@ const dirs = {
   MovieDir : RNFetchBlob.MovieDir,
   DownloadDir : RNFetchBlob.DownloadDir,
   DCIMDir : RNFetchBlob.DCIMDir,
-  get SDCardDir() {
-    console.warn('SDCardDir as a constant is deprecated and will be removed in feature release. ' +
-                 'Use RNFetchBlob.android.getSDCardDir():Promise instead.');
-    return RNFetchBlob.SDCardDir;
-  },
-  get SDCardApplicationDir() {
-    console.warn('SDCardApplicationDir as a constant is deprecated and will be removed in feature release. ' +
-                 'Use RNFetchBlob.android.getSDCardApplicationDir():Promise instead. ' +
-                 'This variable can be empty on error in native code.');
-    return RNFetchBlob.SDCardApplicationDir;
-  },
+  SDCardDir: RNFetchBlob.SDCardDir,
+  SDCardApplicationDir: RNFetchBlob.SDCardApplicationDir,
   MainBundleDir : RNFetchBlob.MainBundleDir,
   LibraryDir : RNFetchBlob.LibraryDir
 }

--- a/fs.js
+++ b/fs.js
@@ -20,9 +20,9 @@ const dirs = {
   MovieDir : RNFetchBlob.MovieDir,
   DownloadDir : RNFetchBlob.DownloadDir,
   DCIMDir : RNFetchBlob.DCIMDir,
-  SDCardDir: RNFetchBlob.SDCardDir,
+  SDCardDir: RNFetchBlob.SDCardDir, // Depracated
   SDCardApplicationDir: RNFetchBlob.SDCardApplicationDir, // Deprecated
-  MainBundleDir : RNFetchBlob.MainBundleDir, // Depracated
+  MainBundleDir : RNFetchBlob.MainBundleDir,
   LibraryDir : RNFetchBlob.LibraryDir
 }
 


### PR DESCRIPTION
This deprecation warnings should go to release notes I guess.
They were printed on fs.js import when it's instantiated.

Fixes #54 